### PR TITLE
Delete user input in user message bulk delete

### DIFF
--- a/commands/clean.js
+++ b/commands/clean.js
@@ -63,6 +63,7 @@ module.exports = {
                             array.pop();
                         }
                         channel.bulkDelete(array).then(() => {
+                            msg.delete();
                             msg.channel.send(`:ok_hand: cleared ${array.length} messages`).then(smsg => {
                                 setTimeout(function() {
                                     smsg.delete();


### PR DESCRIPTION
Fixes a bug where the message in which the clean command is executed from doesn't delete.