### PR TITLE
Assorted fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,6 @@
 	"dependencies": {
 		"@sentry/node": "5.19.1",
 		"@typegoose/typegoose": "^7.0.0",
-		"@types/humanize-duration": "^3.18.0",
-		"@types/javascript-time-ago": "^2.0.1",
-		"@types/lodash": "^4.14.157",
-		"@types/mongoose": "^5.7.12",
-		"@types/node": "^13.13.0",
-		"@types/node-fetch": "^2.5.7",
 		"discord-akairo": "^8.0.0",
 		"discord.js": "^12.2.0",
 		"discord.js-pagination-ts": "^1.0.10",
@@ -26,8 +20,15 @@
 		"mongoose": "^5.9.10",
 		"node-fetch": "^2.6.0",
 		"parse-duration": "^0.4.4",
+		
 		"ts-node": "^8.8.2",
-		"typescript": "^3.8.3"
+		"typescript": "^3.8.3",
+		"@types/humanize-duration": "^3.18.0",
+		"@types/javascript-time-ago": "^2.0.1",
+		"@types/lodash": "^4.14.157",
+		"@types/mongoose": "^5.7.12",
+		"@types/node": "^13.13.0",
+		"@types/node-fetch": "^2.5.7"
 	},
 	"scripts": {
 		"start": "ts-node ."

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
 	"dependencies": {
 		"@sentry/node": "5.19.1",
 		"@typegoose/typegoose": "^7.0.0",
+		"@types/humanize-duration": "^3.18.0",
+		"@types/javascript-time-ago": "^2.0.1",
+		"@types/lodash": "^4.14.157",
+		"@types/mongoose": "^5.7.12",
+		"@types/node": "^13.13.0",
+		"@types/node-fetch": "^2.5.7",
 		"discord-akairo": "^8.0.0",
 		"discord.js": "^12.2.0",
 		"discord.js-pagination-ts": "^1.0.10",
@@ -16,18 +22,12 @@
 		"humanize-duration": "^3.23.0",
 		"javascript-time-ago": "^2.0.7",
 		"lodash": "^4.17.15",
-		"minehut": "^0.0.12",
+		"minehut": "^0.0.14",
 		"mongoose": "^5.9.10",
 		"node-fetch": "^2.6.0",
 		"parse-duration": "^0.4.4",
 		"ts-node": "^8.8.2",
-		"typescript": "^3.8.3",
-		"@types/humanize-duration": "^3.18.0",
-		"@types/javascript-time-ago": "^2.0.1",
-		"@types/lodash": "^4.14.157",
-		"@types/mongoose": "^5.7.12",
-		"@types/node": "^13.13.0",
-		"@types/node-fetch": "^2.5.7"
+		"typescript": "^3.8.3"
 	},
 	"scripts": {
 		"start": "ts-node ."

--- a/src/command/info/server.ts
+++ b/src/command/info/server.ts
@@ -50,7 +50,7 @@ export default class ServerInfoCommand extends MinehutCommand {
 			embed.addField('Suspended?', server.suspended ? 'Yes' : 'No', true);
 			embed.addField('Credits/day', Math.round(server.creditsPerDay), true);
 			const icon = await server.getActiveIcon();
-			embed.addField('Icon', icon.displayName, true);
+			if (icon) embed.addField('Icon', icon.displayName, true);
 			const plugins = await server.getActivePlugins();
 			embed.addField('Plugins', plugins.map(p => `⋆ ${p.name}`).join('\n'));
 			embed.addField(

--- a/src/command/utility/eval.ts
+++ b/src/command/utility/eval.ts
@@ -3,13 +3,12 @@ import { messages, emoji } from '../../util/messages';
 import { inspect } from 'util';
 import { PrefixSupplier } from 'discord-akairo';
 import { MinehutCommand } from '../../structure/command/minehutCommand';
-import { PermissionLevel } from '../../util/permission/permissionLevel';
 
 export default class EvalCommand extends MinehutCommand {
 	constructor() {
 		super('eval', {
 			aliases: ['eval'],
-			permissionLevel: PermissionLevel.BotDeveloper,
+			ownerOnly: true,
 			category: 'utility',
 			description: {
 				content: 'Evaluate JavaScript code',

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@ import * as Sentry from '@sentry/node';
 
 require('dotenv').config();
 
-Sentry.init({
-	dsn: process.env.SENTRY_DSN,
-});
+if (process.env.NODE_ENV === 'production')
+	Sentry.init({
+		dsn: process.env.SENTRY_DSN,
+	});
 
 // TODO: validate env variables
 (async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,10 +370,10 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.43.0"
 
-minehut@^0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/minehut/-/minehut-0.0.12.tgz#4cfe8617039e4c4900069d98deacab106d082f3c"
-  integrity sha512-DyN7vx2tRGzkVgBcAICx7V8QJgUfMCnGv8mpIPCFvPBWhhr6BlVglI4LmJqcdyEL6IzbTj1igyl+eMI5cDEvWg==
+minehut@^0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/minehut/-/minehut-0.0.14.tgz#ed64cd86d3d71bbbbe2794f3253dbe041c498849"
+  integrity sha512-AwTUM8bJ9ta2E1ABKLP1WXWXNTydEEJTqi0b1u4vOw3qFQemooMlibIa8Z7ITpz2U3EimoS9nugcb456ukdwuw==
   dependencies:
     node-fetch "^2.6.0"
 


### PR DESCRIPTION
- Update package used for Minehut API requests to fix a bug
- Only init Sentry if NODE_ENV is production
- Separate dev dependencies and dependencies in package.json with blank line
- Handle missing icon in server command without returning error
- Don't give feedback for missing eval perms