### PR TITLE
Jul 25 patches (1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
 	"dependencies": {
 		"@sentry/node": "5.19.1",
 		"@typegoose/typegoose": "^7.0.0",
+		"@types/humanize-duration": "^3.18.0",
+		"@types/javascript-time-ago": "^2.0.1",
+		"@types/lodash": "^4.14.157",
+		"@types/mongoose": "^5.7.12",
+		"@types/node": "^13.13.0",
+		"@types/node-fetch": "^2.5.7",
 		"discord-akairo": "^8.0.0",
 		"discord.js": "^12.2.0",
 		"discord.js-pagination-ts": "^1.0.10",
@@ -19,16 +25,9 @@
 		"minehut": "^0.0.14",
 		"mongoose": "^5.9.10",
 		"node-fetch": "^2.6.0",
-		"parse-duration": "^0.4.4",
-		
+		"parse-duration": "jellz/parse-duration",
 		"ts-node": "^8.8.2",
-		"typescript": "^3.8.3",
-		"@types/humanize-duration": "^3.18.0",
-		"@types/javascript-time-ago": "^2.0.1",
-		"@types/lodash": "^4.14.157",
-		"@types/mongoose": "^5.7.12",
-		"@types/node": "^13.13.0",
-		"@types/node-fetch": "^2.5.7"
+		"typescript": "^3.8.3"
 	},
 	"scripts": {
 		"start": "ts-node ."

--- a/src/client/minehutClient.ts
+++ b/src/client/minehutClient.ts
@@ -13,6 +13,7 @@ import { CooldownManager } from '../structure/cooldownManager';
 import MinehutClientEvents from './minehutClientEvents';
 
 import { Minehut } from 'minehut';
+import { FOREVER_MS } from '../util/constants';
 
 export class MinehutClient extends AkairoClient {
 	commandHandler: CommandHandler;
@@ -138,6 +139,10 @@ export class MinehutClient extends AkairoClient {
 		this.commandHandler.resolver.addType(
 			'duration',
 			(_msg: Message, phrase) => {
+				if (
+					['p', 'forever', 'permanent', 'perm'].includes(phrase.toLowerCase())
+				)
+					return FOREVER_MS;
 				const parsed = parseDuration(phrase);
 				return parsed;
 			}

--- a/src/command/tag/alias/setAlias.ts
+++ b/src/command/tag/alias/setAlias.ts
@@ -60,7 +60,7 @@ export default class TagSetAliasCommand extends MinehutCommand {
 		msg.channel.send(
 			`${
 				emoji.check
-			} \`${name}\` now points to \`${name}\` (aliases: ${target.aliases.join(
+			} \`${alias}\` now points to \`${name}\` (aliases: ${target.aliases.join(
 				', '
 			)})`
 		);

--- a/src/guild/config/common.ts
+++ b/src/guild/config/common.ts
@@ -1,5 +1,3 @@
-import { PermissionLevel } from '../../util/permission/permissionLevel';
-
 export const ALL_MODLOG_EVENTS = [
 	'memberJoin', //added
 	'memberLeave', //added
@@ -16,7 +14,6 @@ export const ALL_MODLOG_EVENTS = [
 	'command', //added
 ];
 
-export const CENSOR_BYPASS_PERMISSION_LEVEL = PermissionLevel.JuniorModerator;
 export const INVITE_WHITELIST = [
 	'239599059415859200', // Minehut
 	'546414872196415501', // Minehut Meta

--- a/src/guild/config/feature/censor.ts
+++ b/src/guild/config/feature/censor.ts
@@ -17,5 +17,5 @@ export interface CensorConfiguration {
 
 	inviteWhitelist?: string[];
 	minimumChatPermission?: PermissionLevel;
-	minimumBypassPermission: PermissionLevel;
+	minimumBypassPermission?: PermissionLevel;
 }

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -77,6 +77,7 @@ guildConfigs.set('239599059415859200', {
 			channel: '480889821225549824',
 			events: ALL_MODLOG_EVENTS,
 			prefix: '',
+			ignoredChannels: ['601544975221653514'], // #count-to-1mil
 		},
 		reactionRole: {
 			channel: '364453066277388289',

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -154,7 +154,7 @@ guildConfigs.set('546414872196415501', {
 	features: {
 		modLog: {
 			channel: '548317804076597249',
-			events: ALL_MODLOG_EVENTS,
+			events: ALL_MODLOG_EVENTS.filter(e => e !== 'memberUserNameUpdate'),
 			prefix: '',
 		},
 		censor: {

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -1,9 +1,5 @@
 import { GuildConfiguration } from './guildConfiguration';
-import {
-	ALL_MODLOG_EVENTS,
-	CENSOR_BYPASS_PERMISSION_LEVEL,
-	INVITE_WHITELIST,
-} from './common';
+import { ALL_MODLOG_EVENTS, INVITE_WHITELIST } from './common';
 import { PermissionLevel } from '../../util/permission/permissionLevel';
 
 export const guildConfigs: Map<string, GuildConfiguration> = new Map();
@@ -40,14 +36,12 @@ guildConfigs.set('239599059415859200', {
 			],
 		},
 		censor: {
-			minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
 			inviteWhitelist: INVITE_WHITELIST,
 			overrides: [
 				{
 					id: '616367029053554708', // Private category (incl. boosters)
 					type: 'category',
 					config: {
-						minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
 						allowSwearing: true,
 						allowZalgo: true,
 					},
@@ -56,7 +50,6 @@ guildConfigs.set('239599059415859200', {
 					id: '364462035833978881', // Staff category
 					type: 'category',
 					config: {
-						minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
 						allowSwearing: true,
 						allowCopyPasta: true,
 						allowInvites: true,
@@ -67,7 +60,6 @@ guildConfigs.set('239599059415859200', {
 					id: '730111433576284192', // Featured Servers #discussion
 					type: 'channel',
 					config: {
-						minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
 						minimumChatPermission: PermissionLevel.Verified,
 					},
 				},
@@ -160,7 +152,6 @@ guildConfigs.set('546414872196415501', {
 		},
 		censor: {
 			allowSwearing: true,
-			minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
 			minimumChatPermission: PermissionLevel.Everyone,
 			overrides: [],
 		},
@@ -219,7 +210,6 @@ guildConfigs.set('608978588976283660', {
 			],
 		},
 		censor: {
-			minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
 			inviteWhitelist: INVITE_WHITELIST,
 			overrides: [
 				{
@@ -227,7 +217,6 @@ guildConfigs.set('608978588976283660', {
 					type: 'channel',
 					config: {
 						allowSwearing: true,
-						minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
 					},
 				},
 			],

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -1,6 +1,10 @@
-import {GuildConfiguration} from './guildConfiguration';
-import {ALL_MODLOG_EVENTS, CENSOR_BYPASS_PERMISSION_LEVEL, INVITE_WHITELIST,} from './common';
-import {PermissionLevel} from "../../util/permission/permissionLevel";
+import { GuildConfiguration } from './guildConfiguration';
+import {
+	ALL_MODLOG_EVENTS,
+	CENSOR_BYPASS_PERMISSION_LEVEL,
+	INVITE_WHITELIST,
+} from './common';
+import { PermissionLevel } from '../../util/permission/permissionLevel';
 
 export const guildConfigs: Map<string, GuildConfiguration> = new Map();
 
@@ -60,17 +64,13 @@ guildConfigs.set('239599059415859200', {
 					},
 				},
 				{
-					id: '730111433576284192',
+					id: '730111433576284192', // Featured Servers #discussion
 					type: 'channel',
 					config: {
 						minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
-						allowSwearing: false,
-						allowCopyPasta: false,
-						allowInvites: false,
-						allowZalgo: false,
-						minimumChatPermission: PermissionLevel.Verified
-					}
-				}
+						minimumChatPermission: PermissionLevel.Verified,
+					},
+				},
 			],
 		},
 		modLog: {
@@ -156,6 +156,12 @@ guildConfigs.set('546414872196415501', {
 			channel: '548317804076597249',
 			events: ALL_MODLOG_EVENTS,
 			prefix: '',
+		},
+		censor: {
+			allowSwearing: true,
+			minimumBypassPermission: CENSOR_BYPASS_PERMISSION_LEVEL,
+			minimumChatPermission: PermissionLevel.Everyone,
+			overrides: [],
 		},
 	},
 });

--- a/src/listener/missingPermissions.ts
+++ b/src/listener/missingPermissions.ts
@@ -1,7 +1,6 @@
 import { Listener } from 'discord-akairo';
 import { Message } from 'discord.js';
 import { Command } from 'discord-akairo';
-import { messages } from '../util/messages';
 
 export default class MissingPermissionsListener extends Listener {
 	constructor() {
@@ -11,14 +10,11 @@ export default class MissingPermissionsListener extends Listener {
 		});
 	}
 
-	exec(msg: Message, _command: Command, type: string, missing: any) {
-		if (type === 'user')
-			return msg.channel.send(
-				messages.events.commandHandler.missingPermissions.user(missing)
-			);
-		else if (type === 'client')
-			return msg.channel.send(
-				messages.events.commandHandler.missingPermissions.client(missing)
-			);
+	async exec(msg: Message, _command: Command, type: string, _missing: any) {
+		if (type === 'user') msg.react('⛔');
+		else if (type === 'client') {
+			await msg.react('⛔');
+			await msg.react('🤖');
+		}
 	}
 }

--- a/src/listener/modLog/messageDelete.ts
+++ b/src/listener/modLog/messageDelete.ts
@@ -6,6 +6,7 @@ import {
 } from '../../util/functions';
 import { Message } from 'discord.js';
 import { TextChannel } from 'discord.js';
+import _ from 'lodash';
 
 export default class ModLogMessageDeleteListener extends Listener {
 	constructor() {
@@ -33,7 +34,11 @@ export default class ModLogMessageDeleteListener extends Listener {
 				msg.author.id
 			}\`) message deleted in **#${(msg.channel as TextChannel).name}**: (\`${
 				msg.id
-			}\`) ${removeMarkdownAndMentions(msg.content)}`
+			}\`) ${removeMarkdownAndMentions(msg.content)}`,
+			_.take(
+				msg.attachments.map(a => a.proxyURL),
+				20
+			)
 		);
 	}
 }

--- a/src/listener/modLog/messageEdit.ts
+++ b/src/listener/modLog/messageEdit.ts
@@ -6,6 +6,7 @@ import {
 } from '../../util/functions';
 import { Message } from 'discord.js';
 import { TextChannel } from 'discord.js';
+import _ from 'lodash';
 
 export default class ModLogMessageEditListener extends Listener {
 	constructor() {
@@ -37,7 +38,11 @@ export default class ModLogMessageEditListener extends Listener {
 			}\`)\n**Old:** ${removeMarkdownAndMentions(
 				oldMsg.content,
 				oldMsg
-			)}\n**New:** ${removeMarkdownAndMentions(newMsg.content, newMsg)}`
+			)}\n**New:** ${removeMarkdownAndMentions(newMsg.content, newMsg)}`,
+			_.take(
+				newMsg.attachments.map(a => a.proxyURL),
+				20
+			)
 		);
 	}
 }

--- a/src/util/censorRules.ts
+++ b/src/util/censorRules.ts
@@ -72,7 +72,7 @@ export const CENSOR_RULES = [
 	},
 	{ rule: '\\b(blowjob)', type: Swear, enabled: true },
 	{ rule: '\\b(p(e|3)nn?is)', type: Swear, enabled: true },
-	{ rule: '\\b(piss)', type: Swear, enabled: true },
+	{ rule: '\\b(piss)', type: Swear, enabled: false },
 	{ rule: '\\b(c(u)nt)', type: Swear, enabled: true },
 	{ rule: '\\b(whore)', type: Swear, enabled: true },
 	{ rule: '\\b(b(i|\\*)t?ch)', type: Swear, enabled: true },

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -146,7 +146,7 @@ export async function censorMessage(msg: Message) {
 		: featureConf;
 	const bypassCensor =
 		getPermissionLevel(msg.member!, msg.client as MinehutClient) >=
-		censorConfig.minimumBypassPermission;
+		(censorConfig.minimumBypassPermission || PermissionLevel.JuniorModerator);
 	if (bypassCensor) return;
 
 	const canChat =

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -1,13 +1,13 @@
-import {CaseType} from './constants';
+import { CaseType } from './constants';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
-import {guildConfigs} from '../guild/config/guildConfigs';
-import {Guild, Message, TextChannel, Util} from 'discord.js';
-import {CENSOR_RULES, CensorRuleType} from './censorRules';
-import {getPermissionLevel} from './permission/getPermissionLevel';
-import {MinehutClient} from '../client/minehutClient';
-import {cloneDeep} from 'lodash';
-import {PermissionLevel} from "./permission/permissionLevel";
+import { guildConfigs } from '../guild/config/guildConfigs';
+import { Guild, Message, TextChannel, Util } from 'discord.js';
+import { CENSOR_RULES, CensorRuleType } from './censorRules';
+import { getPermissionLevel } from './permission/getPermissionLevel';
+import { MinehutClient } from '../client/minehutClient';
+import { cloneDeep } from 'lodash';
+import { PermissionLevel } from './permission/permissionLevel';
 
 TimeAgo.addLocale(en);
 export const ago = new TimeAgo('en-US');
@@ -99,7 +99,11 @@ export function removeMarkdownAndMentions(content: string, msg?: Message) {
 	);
 }
 
-export async function sendModLogMessage(guild: Guild, content: string) {
+export async function sendModLogMessage(
+	guild: Guild,
+	content: string,
+	attachmentUrls: string[] = []
+) {
 	const config = guildConfigs.get(guild.id);
 	if (!config || !config.features.modLog) return;
 	const channel = guild.client.channels.cache.get(
@@ -109,7 +113,8 @@ export async function sendModLogMessage(guild: Guild, content: string) {
 	channel?.send(
 		`**\`${prettyDate(date, false, false)}\`** ${
 			config.features.modLog.prefix
-		} ${content}`
+		} ${content}`,
+		{ files: attachmentUrls }
 	);
 }
 
@@ -147,8 +152,8 @@ export async function censorMessage(msg: Message) {
 	const canChat =
 		getPermissionLevel(msg.member!, msg.client as MinehutClient) >=
 		(censorConfig.minimumChatPermission || PermissionLevel.Everyone);
-	if(!canChat) {
-		await msg.delete({reason: 'Below needed chat permission level!'})
+	if (!canChat) {
+		await msg.delete({ reason: 'Below needed chat permission level!' });
 		return;
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,10 +443,9 @@ node-fetch@^2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
-parse-duration@^0.4.4:
+parse-duration@jellz/parse-duration:
   version "0.4.4"
-  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-0.4.4.tgz#11c0f51a689e97d06c57bd772f7fda7dc013243c"
-  integrity sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg==
+  resolved "https://codeload.github.com/jellz/parse-duration/tar.gz/f18bf90c8272cb0d494f36e849a80630c02c09ea"
 
 prism-media@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
- Ban/mute command usage is now `mute <user> <duration> [...reason]` instead of `d:` flag
- Use reactions (⛔, 🤖) instead of message reply for Missing Permissions command event
- Add 'mo' duration type as an alternative to 'month'
- Ignore `#count-to-1mil` channel in mod log
- Include file attachments in mod log
- Disallow Discord invites in Meta server
- Fix incorrect message in tag set alias command
- Stop logging username updates in Meta server
- Uncensor "piss"
