### PR TITLE
Add Prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+	"printWidth": 80,
+	"tabWidth": 2,
+	"useTabs": true,
+	"singleQuote": true,
+	"bracketSpacing": true,
+	"arrowParens": "avoid",
+	"proseWrap": "preserve"
+}


### PR DESCRIPTION
Nearly the entirety of the codebase is formatted using [Prettier](https://prettier.io/). This PR adds the Prettier configuration file to the repo so other people who clone the repo and write their own code can use the Prettier extension/CLI to format their code to be consistent with the rest of the codebase. Otherwise, new code will not be correctly formatted, which is not good.