### PR TITLE
Add semi config option to prettierc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
 	"singleQuote": true,
 	"bracketSpacing": true,
 	"arrowParens": "avoid",
-	"proseWrap": "preserve"
+	"proseWrap": "preserve",
+	"semi": true
 }


### PR DESCRIPTION
Having Prettier handle inserting semi-colons where people have forgotten them would prevent things such as this:

![](https://i.imgur.com/lbzs3vk.png)