### PR TITLE
Auto react in channels

### DIFF
--- a/src/guild/config/feature/autoReact.ts
+++ b/src/guild/config/feature/autoReact.ts
@@ -1,0 +1,8 @@
+export interface AutoReactChannel {
+	channel: string;
+	reactions: string[];
+}
+
+export interface AutoReactConfiguration {
+	channels: AutoReactChannel[];
+}

--- a/src/guild/config/feature/autoReact.ts
+++ b/src/guild/config/feature/autoReact.ts
@@ -1,6 +1,8 @@
 export interface AutoReactChannel {
 	channel: string;
 	reactions: string[];
+	allowMessageAuthorReacting: boolean;
+	allowMultipleUserReactions: boolean;
 }
 
 export interface AutoReactConfiguration {

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -154,10 +154,14 @@ guildConfigs.set('546414872196415501', {
 				{
 					channel: '744075635114115142', // #meta-feedback
 					reactions: [':yes:546414872196415501', ':no:546414872196415501'],
+					allowMessageAuthorReacting: false,
+					allowMultipleUserReactions: false,
 				},
 				{
 					channel: '754091669548171357', // #filter-requests
 					reactions: [':yes:546414872196415501', ':no:546414872196415501'],
+					allowMessageAuthorReacting: false,
+					allowMultipleUserReactions: false,
 				},
 			],
 		},

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -217,3 +217,28 @@ guildConfigs.set('608978588976283660', {
 		},
 	},
 });
+
+guildConfigs.set('650778911126323200', {
+	id: '650778911126323200',
+	roles: {
+		admin: '650797870609596418',
+		nitroBooster: '755929113742540841',
+		boostersPass: '755929170185289868',
+		muted: '722920900927815700',
+	},
+	features: {
+		modLog: {
+			channel: '678475231295176706',
+			prefix: '',
+			events: ALL_MODLOG_EVENTS,
+		},
+		autoReact: {
+			channels: [
+				{
+					channel: '658800152047255582',
+					reactions: ['✅', '❌'],
+				},
+			],
+		},
+	},
+});

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -217,28 +217,3 @@ guildConfigs.set('608978588976283660', {
 		},
 	},
 });
-
-guildConfigs.set('650778911126323200', {
-	id: '650778911126323200',
-	roles: {
-		admin: '650797870609596418',
-		nitroBooster: '755929113742540841',
-		boostersPass: '755929170185289868',
-		muted: '722920900927815700',
-	},
-	features: {
-		modLog: {
-			channel: '678475231295176706',
-			prefix: '',
-			events: ALL_MODLOG_EVENTS,
-		},
-		autoReact: {
-			channels: [
-				{
-					channel: '658800152047255582',
-					reactions: ['✅', '❌'],
-				},
-			],
-		},
-	},
-});

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -149,6 +149,18 @@ guildConfigs.set('546414872196415501', {
 			minimumChatPermission: PermissionLevel.Everyone,
 			overrides: [],
 		},
+		autoReact: {
+			channels: [
+				{
+					channel: '744075635114115142', // #meta-feedback
+					reactions: [':yes:546414872196415501', ':no:546414872196415501'],
+				},
+				{
+					channel: '754091669548171357', // #filter-requests
+					reactions: [':yes:546414872196415501', ':no:546414872196415501'],
+				},
+			],
+		},
 	},
 });
 

--- a/src/guild/config/guildConfiguration.ts
+++ b/src/guild/config/guildConfiguration.ts
@@ -3,6 +3,7 @@ import { ModLogConfiguration } from './feature/modLog';
 import { ReactionRoleConfiguration } from './feature/reactionRole';
 import { AnnouncementConfiguration } from './feature/announcement';
 import { CensorConfiguration } from './feature/censor';
+import { AutoReactConfiguration } from './feature/autoReact';
 
 // The GuildConfiguration can have settings about permissions, log channels, disabled features, etc.
 export interface GuildConfiguration {
@@ -15,5 +16,6 @@ export interface GuildConfiguration {
 		reactionRole?: ReactionRoleConfiguration;
 		announcement?: AnnouncementConfiguration;
 		censor?: CensorConfiguration;
+		autoReact?: AutoReactConfiguration;
 	};
 }

--- a/src/listener/autoReact.ts
+++ b/src/listener/autoReact.ts
@@ -1,0 +1,23 @@
+import { Listener } from 'discord-akairo';
+import { Message } from 'discord.js';
+import { guildConfigs } from '../guild/config/guildConfigs';
+
+export default class AutoReactListener extends Listener {
+	constructor() {
+		super('autoReact', {
+			emitter: 'client',
+			event: 'message',
+		});
+	}
+
+	async exec(msg: Message) {
+		if (!msg.guild) return;
+		const autoReactConfig = guildConfigs.get(msg.guild.id)?.features.autoReact;
+		if (!autoReactConfig || !autoReactConfig.channels) return;
+		const autoReactChannel = autoReactConfig.channels.find(
+			c => c.channel === msg.channel.id
+		);
+		if (!autoReactChannel) return;
+		autoReactChannel.reactions.forEach(async r => await msg.react(r));
+	}
+}

--- a/src/listener/autoReact/autoReactMessage.ts
+++ b/src/listener/autoReact/autoReactMessage.ts
@@ -1,10 +1,10 @@
 import { Listener } from 'discord-akairo';
 import { Message } from 'discord.js';
-import { guildConfigs } from '../guild/config/guildConfigs';
+import { guildConfigs } from '../../guild/config/guildConfigs';
 
-export default class AutoReactListener extends Listener {
+export default class AutoReactMessageListener extends Listener {
 	constructor() {
-		super('autoReact', {
+		super('autoReactMessage', {
 			emitter: 'client',
 			event: 'message',
 		});

--- a/src/listener/autoReact/autoReactionAddedByUser.ts
+++ b/src/listener/autoReact/autoReactionAddedByUser.ts
@@ -1,0 +1,40 @@
+import { Listener } from 'discord-akairo';
+import { User } from 'discord.js';
+import { MessageReaction } from 'discord.js';
+import { guildConfigs } from '../../guild/config/guildConfigs';
+
+export default class AutoReactionAddedByUserListener extends Listener {
+	constructor() {
+		super('autoReactionAddedByUser', {
+			emitter: 'client',
+			event: 'messageReactionAdd',
+		});
+	}
+
+	async exec(reaction: MessageReaction, user: User) {
+		const msg = reaction.message;
+		if (!msg.guild || user.bot) return;
+		const autoReactConfig = guildConfigs.get(msg.guild.id)?.features.autoReact;
+		if (!autoReactConfig || !autoReactConfig.channels) return;
+		const autoReactChannel = autoReactConfig.channels.find(
+			c => c.channel === msg.channel.id
+		);
+		if (!autoReactChannel) return;
+		const autoReactions = msg.reactions.cache.filter(r =>
+			autoReactChannel.reactions.includes(
+				r.emoji.toString().replace(/[<>]/g, '')
+			)
+		);
+		if (
+			autoReactions.some(r => r === reaction) &&
+			!autoReactChannel.allowMessageAuthorReacting &&
+			msg.author === user
+		)
+			return reaction.users.remove(user);
+		if (
+			autoReactions.some(r => r !== reaction && r.users.cache.has(user.id)) &&
+			!autoReactChannel.allowMultipleUserReactions
+		)
+			return reaction.users.remove(user);
+	}
+}

--- a/src/listener/reactionRaw.ts
+++ b/src/listener/reactionRaw.ts
@@ -8,9 +8,9 @@ interface RawPacket {
 	op: number;
 }
 
-export default class ReactionRoleRawListener extends Listener {
+export default class ReactionRawListener extends Listener {
 	constructor() {
-		super('reactionRoleRaw', {
+		super('reactionRaw', {
 			emitter: 'client',
 			event: 'raw',
 		});

--- a/src/listener/reactionRole/join.ts
+++ b/src/listener/reactionRole/join.ts
@@ -13,7 +13,7 @@ export default class ReactionRoleJoinListener extends Listener {
 
 	async exec(reaction: MessageReaction, user: User) {
 		const message = reaction.message;
-		if (!message.guild) return;
+		if (!message.guild || user.bot) return;
 		const config = guildConfigs.get(message.guild.id);
 		if (
 			!config ||

--- a/src/listener/reactionRole/leave.ts
+++ b/src/listener/reactionRole/leave.ts
@@ -13,7 +13,7 @@ export default class ReactionRoleLeaveListener extends Listener {
 
 	async exec(reaction: MessageReaction, user: User) {
 		const message = reaction.message;
-		if (!message.guild) return;
+		if (!message.guild || user.bot) return;
 		const config = guildConfigs.get(message.guild.id);
 		if (
 			!config ||


### PR DESCRIPTION
This adds configuration to auto react to any message posted in a configured channel. It was made for Minehut Meta channels #feedback-meta and #filter-requests.

Closes Minehut/Meta#318

**Configuration Changes**:
* Adds an `autoRole` property to the `features` property. 