### PR TITLE
Bot status based on network status (#5)

### DIFF
--- a/src/listener/ready.ts
+++ b/src/listener/ready.ts
@@ -28,6 +28,16 @@ export default class ReadyListener extends Listener {
 			this.client.user?.setActivity(`👀 ${memberCount}`, {
 				type: 'WATCHING',
 			});
+
+			const updateStatus = async () => {
+				try {
+					const simpleStats = await this.client.minehutApi.getSimpleStats();
+					if (simpleStats.playerCount == 0 || simpleStats.serverCount == 0) return this.client.user?.setStatus('idle');
+					this.client.user?.setStatus('online');
+				} catch(e) this.client.user?.setStatus('dnd');
+			}
+
+			setInterval(updateStatus, 30000);
 		}
 
 		await this.client.banScheduler.refresh();

--- a/src/listener/ready.ts
+++ b/src/listener/ready.ts
@@ -34,7 +34,9 @@ export default class ReadyListener extends Listener {
 					const simpleStats = await this.client.minehutApi.getSimpleStats();
 					if (simpleStats.playerCount == 0 || simpleStats.serverCount == 0) return this.client.user?.setStatus('idle');
 					this.client.user?.setStatus('online');
-				} catch(e) this.client.user?.setStatus('dnd');
+				} catch(e) { 
+					this.client.user?.setStatus('dnd');
+				}
 			}
 
 			setInterval(updateStatus, 30000);


### PR DESCRIPTION
Resolves #5 

Changes the Bot's status based on Minehut's status:
- `online`: everything is going well
- `idle`: minehut is up, but no servers are up, or no players are on
- `dnd`: the api isn't responding

It check's Minehut's status every 30 seconds.