### PR TITLE
Channel Cooldown Command

### DIFF
--- a/src/client/minehutClientEvents.ts
+++ b/src/client/minehutClientEvents.ts
@@ -4,12 +4,14 @@ import { Case } from '../model/case';
 import { GuildMember } from 'discord.js';
 import { Message } from 'discord.js';
 import { CensorCheckResponse } from '../util/functions';
+import { TextChannel } from 'discord.js';
 
 export default interface MinehutClientEvents extends ClientEvents {
 	caseUpdate: [DocumentType<Case>, DocumentType<Case>, GuildMember];
 	caseDelete: [DocumentType<Case>, GuildMember];
 	caseCreate: [DocumentType<Case>];
 	messageCensor: [Message, CensorCheckResponse];
+	channelCooldownSet: [TextChannel, GuildMember, number];
 }
 
 export type MinehutClientEvent = keyof MinehutClientEvents;

--- a/src/command/mod/cooldown.ts
+++ b/src/command/mod/cooldown.ts
@@ -1,0 +1,86 @@
+import { MinehutCommand } from '../../structure/command/minehutCommand';
+import { PermissionLevel } from '../../util/permission/permissionLevel';
+import { Message } from 'discord.js';
+import { Channel } from 'discord.js';
+import { TextChannel } from 'discord.js';
+import humanizeDuration from 'humanize-duration';
+
+export default class ChannelCooldownCommand extends MinehutCommand {
+	constructor() {
+		super('cooldown', {
+			aliases: ['cooldown'],
+			category: 'mod',
+			channel: 'guild',
+			permissionLevel: PermissionLevel.Moderator,
+			description: {
+				content: 'Set a cooldown for a channel',
+				usage: '<channel> <cooldown>',
+				examples: ['#general 5s', '#random 10s'],
+			},
+			args: [
+				{
+					id: 'channel',
+					type: 'channel',
+					prompt: {
+						start: (msg: Message) =>
+							`${msg.author}, which channel would you like to set a cooldown for?`,
+						retry: (msg: Message) =>
+							`${msg.author}, please specify a valid channel.`,
+					},
+				},
+				{
+					id: 'duration',
+					type: 'duration',
+					prompt: {
+						start: (msg: Message) =>
+							`${msg.author}, how long should the cooldown be?`,
+						retry: (msg: Message) =>
+							`${msg.author}, please specify a valid duration.`,
+					},
+				},
+			],
+		});
+	}
+
+	async exec(
+		msg: Message,
+		{ channel, duration }: { channel: Channel; duration: number }
+	) {
+		if (channel.type !== 'text')
+			return msg.channel.send(
+				`${process.env.EMOJI_CROSS} specified channel is not a text channel`
+			);
+
+		const textChannel = channel as TextChannel;
+		const durationInSeconds = duration / 1000;
+		const humanReadable = humanizeDuration(duration, {
+			largest: 3,
+			round: true,
+		});
+
+		if (textChannel.rateLimitPerUser === 0 && durationInSeconds === 0)
+			return msg.channel.send(
+				`${process.env.EMOJI_CROSS} cannot disable cooldown when cooldown is already disabled`
+			);
+		if (textChannel.rateLimitPerUser === durationInSeconds)
+			return msg.channel.send(
+				`${process.env.EMOJI_CROSS} channel cooldown is already set to this duration`
+			);
+		if (durationInSeconds > 21600)
+			return msg.channel.send(
+				`${process.env.EMOJI_CROSS} cannot set cooldown to be longer than 6 hours`
+			);
+
+		textChannel.setRateLimitPerUser(durationInSeconds);
+		this.client.emit('channelCooldownSet', textChannel, msg.member!, duration);
+
+		if (durationInSeconds === 0)
+			return msg.channel.send(
+				`${process.env.EMOJI_CHECK} disabled cooldown for channel **${textChannel}**`
+			);
+		else
+			return msg.channel.send(
+				`${process.env.EMOJI_CHECK} set cooldown for channel **${textChannel}** to **${humanReadable}**`
+			);
+	}
+}

--- a/src/command/mod/cooldown.ts
+++ b/src/command/mod/cooldown.ts
@@ -14,7 +14,7 @@ export default class ChannelCooldownCommand extends MinehutCommand {
 			permissionLevel: PermissionLevel.Moderator,
 			description: {
 				content: 'Set a cooldown for a channel',
-				usage: '<channel> <cooldown>',
+				usage: '<channel> <duration>',
 				examples: ['#general 5s', '#random 10s'],
 			},
 			args: [

--- a/src/listener/modLog/channelCooldownSet.ts
+++ b/src/listener/modLog/channelCooldownSet.ts
@@ -1,0 +1,32 @@
+import { Listener } from 'discord-akairo';
+import { GuildMember } from 'discord.js';
+import { TextChannel } from 'discord.js';
+import { sendModLogMessage } from '../../util/functions';
+import humanizeDuration from 'humanize-duration';
+
+export default class ModLogChannelCooldownSetListener extends Listener {
+	constructor() {
+		super('channelCooldownSet', {
+			emitter: 'client',
+			event: 'channelCooldownSet',
+		});
+	}
+
+	async exec(channel: TextChannel, member: GuildMember, duration: number) {
+		const humanizedDuration = humanizeDuration(duration, {
+			largest: 3,
+			round: true,
+		});
+
+		if (duration === 0)
+			await sendModLogMessage(
+				channel.guild,
+				`:clock: **${member.user.tag}** (\`${member.id}\`) disabled cooldown in **${channel.name}** (\`${channel.id}\`)`
+			);
+		else
+			await sendModLogMessage(
+				channel.guild,
+				`:clock: **${member.user.tag}** (\`${member.id}\`) set cooldown in **${channel.name}** (\`${channel.id}\`) to **${humanizedDuration}**`
+			);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Minehut/Meta/issues/335

Adds a command to set the cooldown for a channel so moderators can set cooldowns in a channel without needing to ask a senior moderator to do so.