### PR TITLE
Hastebin Conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"discord.js": "^12.2.0",
 		"discord.js-pagination-ts": "^1.0.10",
 		"dotenv": "^8.2.0",
+		"hastebin-gen": "^2.0.5",
 		"humanize-duration": "^3.23.0",
 		"javascript-time-ago": "^2.0.7",
 		"lodash": "^4.17.19",

--- a/src/client/minehutClient.ts
+++ b/src/client/minehutClient.ts
@@ -23,6 +23,7 @@ export class MinehutClient extends AkairoClient {
 	muteScheduler: MuteScheduler;
 
 	tagCooldownManager: CooldownManager;
+	hastebinCooldownManager: CooldownManager;
 
 	minehutApi: Minehut;
 
@@ -92,6 +93,7 @@ export class MinehutClient extends AkairoClient {
 		this.muteScheduler = new MuteScheduler(this);
 
 		this.tagCooldownManager = new CooldownManager(10000);
+		this.hastebinCooldownManager = new CooldownManager(10000);
 
 		this.minehutApi = new Minehut();
 
@@ -169,6 +171,7 @@ declare module 'discord-akairo' {
 		banScheduler: BanScheduler;
 		muteScheduler: MuteScheduler;
 		tagCooldownManager: CooldownManager;
+		hastebinCooldownManager: CooldownManager;
 		minehutApi: Minehut;
 
 		start(token: string): void;

--- a/src/guild/config/feature/hastbinConversion.ts
+++ b/src/guild/config/feature/hastbinConversion.ts
@@ -1,0 +1,4 @@
+export interface HastebinConversionConfiguration {
+	channels: string[];
+	whitelistedExtensions: string[];
+}

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -74,7 +74,7 @@ guildConfigs.set('239599059415859200', {
 			],
 		},
 		hastebinConversion: {
-			channels: ['412394499919052810'],
+			channels: ['412394499919052810', '660337933743816724', '400170127737356299'],
 			whitelistedExtensions: ['txt']
 		}
 	},

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -75,7 +75,7 @@ guildConfigs.set('239599059415859200', {
 		},
 		hastebinConversion: {
 			channels: ['412394499919052810', '660337933743816724', '400170127737356299'],
-			whitelistedExtensions: ['txt']
+			whitelistedExtensions: ['txt', 'log', 'json', 'yml', 'yaml', 'properties', 'sk']
 		}
 	},
 });

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -73,6 +73,10 @@ guildConfigs.set('239599059415859200', {
 				{ roleId: '493253127366115360', emoji: 'HypeBadge' },
 			],
 		},
+		hastebinConversion: {
+			channels: ['412394499919052810'],
+			whitelistedExtensions: ['txt']
+		}
 	},
 });
 

--- a/src/guild/config/guildConfiguration.ts
+++ b/src/guild/config/guildConfiguration.ts
@@ -4,6 +4,7 @@ import { ReactionRoleConfiguration } from './feature/reactionRole';
 import { AnnouncementConfiguration } from './feature/announcement';
 import { CensorConfiguration } from './feature/censor';
 import { AutoReactConfiguration } from './feature/autoReact';
+import { HastebinConversionConfiguration } from './feature/hastbinConversion';
 
 // The GuildConfiguration can have settings about permissions, log channels, disabled features, etc.
 export interface GuildConfiguration {
@@ -17,5 +18,6 @@ export interface GuildConfiguration {
 		announcement?: AnnouncementConfiguration;
 		censor?: CensorConfiguration;
 		autoReact?: AutoReactConfiguration;
+		hastebinConversion?: HastebinConversionConfiguration;
 	};
 }

--- a/src/listener/hastebinConversion.ts
+++ b/src/listener/hastebinConversion.ts
@@ -1,0 +1,51 @@
+import { Listener } from 'discord-akairo';
+import { Message } from 'discord.js';
+import fetch from 'node-fetch';
+import { guildConfigs } from '../guild/config/guildConfigs';
+import hastebin from 'hastebin-gen';
+import { MessageEmbed } from 'discord.js';
+
+export default class HastebinConversionListener extends Listener {
+	constructor() {
+		super('hastebinConversion', {
+			emitter: 'client',
+			event: 'message',
+		});
+	}
+
+	async exec(msg: Message) {
+		if (!msg.guild) return;
+
+		const hastebinConversionConfig = guildConfigs.get(msg.guild.id)?.features
+			.hastebinConversion;
+		if (
+			!hastebinConversionConfig ||
+			!hastebinConversionConfig.channels.includes(msg.channel.id)
+		)
+			return;
+
+		const messageAttachment = msg.attachments.find(attachment =>
+			hastebinConversionConfig.whitelistedExtensions.some(ext =>
+				attachment.name?.endsWith(ext)
+			)
+		);
+		if (!messageAttachment) return;
+
+		if (this.client.hastebinCooldownManager.isOnCooldown(msg.author.id))
+			return msg.react('⏲️');
+
+		const res = await fetch(messageAttachment.url);
+		const text = await res.text();
+		const hastebinUrl = await hastebin(text, {
+			extension: messageAttachment.name?.substring(
+				messageAttachment.name.indexOf('.') + 1
+			),
+		});
+		const embed = new MessageEmbed()
+			.setTitle(hastebinUrl)
+			.setFooter(`Requested by ${msg.author.tag}`, msg.author.avatarURL()!)
+			.setColor('BLUE');
+		await msg.channel.send(embed);
+		this.client.hastebinCooldownManager.add(msg.author.id);
+	}
+}

--- a/src/listener/hastebinConversion.ts
+++ b/src/listener/hastebinConversion.ts
@@ -26,7 +26,7 @@ export default class HastebinConversionListener extends Listener {
 
 		const messageAttachment = msg.attachments.find(attachment =>
 			hastebinConversionConfig.whitelistedExtensions.some(ext =>
-				attachment.name?.endsWith(ext)
+				attachment.name?.endsWith(`.${ext}`)
 			)
 		);
 		if (!messageAttachment) return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,6 +303,13 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+hastebin-gen@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/hastebin-gen/-/hastebin-gen-2.0.5.tgz#8f4f11d5c4890280e2dbd34217e6ff06d053fe68"
+  integrity sha512-At1LaKtcqh2jiP8xfE2sDGT9IshIki6FqsgLwn2y7FzAvlFJRtpUsSPh3yWjWIQIvxi/GPF07IBqSI8WhPL/gQ==
+  dependencies:
+    node-fetch "^2.6.0"
+
 https-proxy-agent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"


### PR DESCRIPTION
Converts message attachments with a configured whitelisted extension to a hastebin link and sends it when such a message attachment is sent in a configured channel. It also has a cooldown of 10 seconds to ensure people can't spam attachments.

Closes https://github.com/Minehut/Meta/issues/384