### PR TITLE
Hastebin Conversion Changes

### DIFF
--- a/src/guild/config/common.ts
+++ b/src/guild/config/common.ts
@@ -14,6 +14,16 @@ export const ALL_MODLOG_EVENTS = [
 	'command', //added
 ];
 
+export const HASTEBIN_EXTENSIONS_WHITELIST = [
+	'txt',
+	'log',
+	'json',
+	'yml',
+	'yaml',
+	'properties',
+	'sk',
+];
+
 export const INVITE_WHITELIST = [
 	'239599059415859200', // Minehut
 	'546414872196415501', // Minehut Meta

--- a/src/guild/config/feature/hastbinConversion.ts
+++ b/src/guild/config/feature/hastbinConversion.ts
@@ -1,1 +1,4 @@
-export interface HastebinConversionConfiguration {}
+export interface HastebinConversionConfiguration {
+	ignoredChannels?: string[];
+	whitelistedExtensions: string[];
+}

--- a/src/guild/config/feature/hastbinConversion.ts
+++ b/src/guild/config/feature/hastbinConversion.ts
@@ -1,4 +1,1 @@
-export interface HastebinConversionConfiguration {
-	channels: string[];
-	whitelistedExtensions: string[];
-}
+export interface HastebinConversionConfiguration {}

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -1,5 +1,5 @@
 import { GuildConfiguration } from './guildConfiguration';
-import { ALL_MODLOG_EVENTS, INVITE_WHITELIST } from './common';
+import { ALL_MODLOG_EVENTS, HASTEBIN_EXTENSIONS_WHITELIST, INVITE_WHITELIST } from './common';
 import { PermissionLevel } from '../../util/permission/permissionLevel';
 
 export const guildConfigs: Map<string, GuildConfiguration> = new Map();
@@ -74,7 +74,8 @@ guildConfigs.set('239599059415859200', {
 			],
 		},
 		hastebinConversion: {
-
+			ignoredChannels: ['480889821225549824'],
+			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
 		}
 	},
 });
@@ -169,7 +170,8 @@ guildConfigs.set('546414872196415501', {
 			],
 		},
 		hastebinConversion: {
-
+			ignoredChannels: ['548317804076597249'],
+			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
 		}
 	},
 });

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -74,8 +74,7 @@ guildConfigs.set('239599059415859200', {
 			],
 		},
 		hastebinConversion: {
-			channels: ['412394499919052810', '660337933743816724', '400170127737356299'],
-			whitelistedExtensions: ['txt', 'log', 'json', 'yml', 'yaml', 'properties', 'sk']
+
 		}
 	},
 });
@@ -169,6 +168,9 @@ guildConfigs.set('546414872196415501', {
 				},
 			],
 		},
+		hastebinConversion: {
+
+		}
 	},
 });
 

--- a/src/listener/hastebinConversion.ts
+++ b/src/listener/hastebinConversion.ts
@@ -3,7 +3,6 @@ import { Message } from 'discord.js';
 import fetch from 'node-fetch';
 import { guildConfigs } from '../guild/config/guildConfigs';
 import { MessageEmbed } from 'discord.js';
-import { WHITELISTED_HASTEBIN_FILE_EXTENSIONS } from '../util/constants';
 import { generateHastebinFromInput } from '../util/functions';
 
 export default class HastebinConversionListener extends Listener {
@@ -22,7 +21,7 @@ export default class HastebinConversionListener extends Listener {
 		if (!hastebinConversionConfig) return;
 
 		const messageAttachment = msg.attachments.find(attachment =>
-			WHITELISTED_HASTEBIN_FILE_EXTENSIONS.some(ext =>
+			hastebinConversionConfig.whitelistedExtensions.some(ext =>
 				attachment.name?.endsWith(`.${ext}`)
 			)
 		);

--- a/src/listener/hastebinConversion.ts
+++ b/src/listener/hastebinConversion.ts
@@ -18,7 +18,11 @@ export default class HastebinConversionListener extends Listener {
 
 		const hastebinConversionConfig = guildConfigs.get(msg.guild.id)?.features
 			.hastebinConversion;
-		if (!hastebinConversionConfig) return;
+		if (
+			!hastebinConversionConfig ||
+			hastebinConversionConfig.ignoredChannels?.includes(msg.channel.id)
+		)
+			return;
 
 		const messageAttachment = msg.attachments.find(attachment =>
 			hastebinConversionConfig.whitelistedExtensions.some(ext =>
@@ -35,7 +39,9 @@ export default class HastebinConversionListener extends Listener {
 
 		const hastebinUrl = await generateHastebinFromInput(
 			text,
-			messageAttachment.name?.substring(messageAttachment.name.indexOf('.') + 1)!
+			messageAttachment.name?.substring(
+				messageAttachment.name.indexOf('.') + 1
+			)!
 		);
 		const embed = new MessageEmbed()
 			.setTitle(hastebinUrl)

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -165,5 +165,3 @@ export const ZALGO_REGEX = new RegExp(
 export const IMGUR_LINK_REGEX = /((?:https?:)?\/\/(\w+\.)?imgur\.com\/(\S*)(\.[a-zA-Z]{3}))/im;
 
 export const HASTEBIN_URI = 'https://hastebin.com';
-
-export const WHITELISTED_HASTEBIN_FILE_EXTENSIONS = ['txt', 'log', 'json', 'yml', 'yaml', 'properties', 'sk'];

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -163,3 +163,7 @@ export const ZALGO_REGEX = new RegExp(
 );
 
 export const IMGUR_LINK_REGEX = /((?:https?:)?\/\/(\w+\.)?imgur\.com\/(\S*)(\.[a-zA-Z]{3}))/im;
+
+export const HASTEBIN_URI = 'https://hastebin.com';
+
+export const WHITELISTED_HASTEBIN_FILE_EXTENSIONS = ['txt', 'log', 'json', 'yml', 'yaml', 'properties', 'sk'];

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -1,4 +1,4 @@
-import { CaseType } from './constants';
+import { CaseType, HASTEBIN_URI } from './constants';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 import { guildConfigs } from '../guild/config/guildConfigs';
@@ -8,6 +8,7 @@ import { getPermissionLevel } from './permission/getPermissionLevel';
 import { MinehutClient } from '../client/minehutClient';
 import { cloneDeep } from 'lodash';
 import { PermissionLevel } from './permission/permissionLevel';
+import fetch from 'node-fetch';
 
 TimeAgo.addLocale(en);
 export const ago = new TimeAgo('en-US');
@@ -215,4 +216,16 @@ export function checkString(content: string): CensorCheckResponse | undefined {
 		const match = content.match(regex);
 		if (match) return { rule, match };
 	}
+}
+
+export async function generateHastebinFromInput(input: string, ext: string) {
+	const res = await fetch(`${HASTEBIN_URI}/documents`, {
+		method: 'POST',
+		body: input,
+		headers: { 'Content-Type': 'text/plain' },
+	});
+	if (!res.ok)
+		throw new Error(`Error while generating hastebin: ${res.statusText}`);
+	const { key }: { key: string } = await res.json();
+	return `${HASTEBIN_URI}/${key}.${ext}`;
 }


### PR DESCRIPTION
This PR changes some things about the Hastebin conversion feature:

* Changes file conversion from a per-channel basis to a global basis with the option to ignore channels in the guild
* Adds a guild configuration common constant for whitelisted extensions
* Removes the `hastebin-gen` dependency and instead uses a function inside of the codebase
* Enables the feature for meta