### PR TITLE
Add a github issue reference (and a cache manager)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
 	"license": "GPL-3.0-or-later",
 	"private": true,
 	"dependencies": {
+		"@octokit/rest": "^18.0.7",
+		"@octokit/types": "^5.5.0",
 		"@sentry/node": "5.19.1",
 		"@typegoose/typegoose": "^7.0.0",
 		"@types/humanize-duration": "^3.18.0",

--- a/src/client/minehutClient.ts
+++ b/src/client/minehutClient.ts
@@ -13,6 +13,9 @@ import MinehutClientEvents from './minehutClientEvents';
 
 import { Minehut } from 'minehut';
 import { FOREVER_MS, MESSAGES } from '../util/constants';
+import { CacheManager } from '../structure/cacheManager';
+
+import { OctokitResponse, IssuesGetResponseData } from '@octokit/types';
 
 export class MinehutClient extends AkairoClient {
 	commandHandler: CommandHandler;
@@ -23,6 +26,9 @@ export class MinehutClient extends AkairoClient {
 	muteScheduler: MuteScheduler;
 
 	tagCooldownManager: CooldownManager;
+	githubCooldownManager: CooldownManager;
+
+	githubCacheManager: CacheManager<number, any>;
 
 	minehutApi: Minehut;
 
@@ -92,6 +98,9 @@ export class MinehutClient extends AkairoClient {
 		this.muteScheduler = new MuteScheduler(this);
 
 		this.tagCooldownManager = new CooldownManager(10000);
+		this.githubCooldownManager = new CooldownManager(10000);
+
+		this.githubCacheManager = new CacheManager();
 
 		this.minehutApi = new Minehut();
 
@@ -169,6 +178,11 @@ declare module 'discord-akairo' {
 		banScheduler: BanScheduler;
 		muteScheduler: MuteScheduler;
 		tagCooldownManager: CooldownManager;
+		githubCooldownManager: CooldownManager;
+		githubCacheManager: CacheManager<
+			number,
+			Promise<OctokitResponse<IssuesGetResponseData>>
+		>;
 		minehutApi: Minehut;
 
 		start(token: string): void;

--- a/src/guild/config/feature/githubIssue.ts
+++ b/src/guild/config/feature/githubIssue.ts
@@ -1,0 +1,5 @@
+export interface GithubIssueReferenceConfiguration {
+    githubRepoOwner: string;
+    githubRepoName: string;
+    ignoredChannels?: string[];
+}

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -172,7 +172,7 @@ guildConfigs.set('546414872196415501', {
 		hastebinConversion: {
 			ignoredChannels: ['548317804076597249'],
 			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
-   },
+    },
 		githubIssue: {
 			githubRepoOwner: "Minehut",
 			githubRepoName: "Meta",

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -172,7 +172,7 @@ guildConfigs.set('546414872196415501', {
 		hastebinConversion: {
 			ignoredChannels: ['548317804076597249'],
 			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
-    },
+    	},
 		githubIssue: {
 			githubRepoOwner: "Minehut",
 			githubRepoName: "Meta",

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -172,7 +172,7 @@ guildConfigs.set('546414872196415501', {
 		hastebinConversion: {
 			ignoredChannels: ['548317804076597249'],
 			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
-    	},
+   },
 		githubIssue: {
 			githubRepoOwner: "Minehut",
 			githubRepoName: "Meta",

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -149,6 +149,10 @@ guildConfigs.set('546414872196415501', {
 			minimumChatPermission: PermissionLevel.Everyone,
 			overrides: [],
 		},
+		githubIssue: {
+			githubRepoOwner: "Minehut",
+			githubRepoName: "Meta",
+		}
 	},
 });
 

--- a/src/guild/config/guildConfiguration.ts
+++ b/src/guild/config/guildConfiguration.ts
@@ -3,6 +3,7 @@ import { ModLogConfiguration } from './feature/modLog';
 import { ReactionRoleConfiguration } from './feature/reactionRole';
 import { AnnouncementConfiguration } from './feature/announcement';
 import { CensorConfiguration } from './feature/censor';
+import { GithubIssueReferenceConfiguration } from './feature/githubIssue';
 
 // The GuildConfiguration can have settings about permissions, log channels, disabled features, etc.
 export interface GuildConfiguration {
@@ -15,5 +16,6 @@ export interface GuildConfiguration {
 		reactionRole?: ReactionRoleConfiguration;
 		announcement?: AnnouncementConfiguration;
 		censor?: CensorConfiguration;
+		githubIssue?: GithubIssueReferenceConfiguration;
 	};
 }

--- a/src/listener/githubIssueReference.ts
+++ b/src/listener/githubIssueReference.ts
@@ -1,0 +1,75 @@
+import { Listener } from 'discord-akairo';
+import { Message, MessageEmbed } from 'discord.js';
+import { truncate } from 'lodash';
+import { guildConfigs } from '../guild/config/guildConfigs';
+import { capitalize } from 'lodash';
+import { MinehutClient } from '../client/minehutClient';
+import { getIssue } from '../util/functions';
+
+export default class GithubIssueReferenceListener extends Listener {
+	client: MinehutClient;
+
+	constructor(client: MinehutClient) {
+		super('githubIssueReference', {
+			emitter: 'commandHandler',
+			event: 'messageInvalid',
+		});
+		this.client = client;
+	}
+	async exec(msg: Message) {
+		if (!msg.guild) return;
+		const config = guildConfigs.get(msg.guild.id);
+		if (!config || !config.features.githubIssue) return;
+		if (config.features.githubIssue.ignoredChannels?.includes(msg.channel.id))
+			return;
+		const messageMatch = msg.content.match(/#\d+/);
+
+		if (messageMatch) {
+			const issueNumber = parseInt(messageMatch[0].slice(1));
+			if (
+				this.client.githubCooldownManager.isOnCooldown(
+					`gh-${issueNumber}-${msg.channel.id}`
+				)
+			)
+				return msg.react('⏲️');
+			const issue = await getIssue(
+				this.client,
+				config.features.githubIssue.githubRepoOwner,
+				config.features.githubIssue.githubRepoName,
+				issueNumber
+			);
+			if (issue) {
+				const embed = new MessageEmbed()
+					.setTitle(`${issue.data.title} (#${issue.data.number})`)
+					.setURL(issue.data.html_url);
+				const body = issue.data.body
+					.replace(/<!--(.|\n|\r)*?-->/g, '') // Removes markdown comments
+					.replace(/(\n|\r){3,}/gi, '\n\n') // Replaces line breaks of 3 lines, or more, with 2
+					.trim()
+					.replace(
+						/(.|\n|\r)*Checklist*((.|\n|\r)*?(((-( )?)?\[.*\]|-))){4}.+/gi,
+						''
+					) // Remove checklist
+					.replace(/(\*\*.+\*\*)\n\n/gi, '$1\n'); // Removes space after headers to make embeds more compact
+				embed
+					.setDescription(truncate(body, { length: 500 }))
+					.setAuthor(
+						issue.data.user.login,
+						issue.data.user.avatar_url,
+						issue.data.user.avatar_url
+					)
+					.setColor(issue.data.state === 'open' ? 'GREEN' : 'RED')
+					.setFooter(
+						issue.data.labels
+							.map((m: { name: string }) => m.name.replace(/\w+/g, capitalize))
+							.join(' • ')
+					)
+					.setTimestamp(Date.parse(issue.data.created_at));
+				await msg.channel.send(embed);
+				this.client.githubCooldownManager.add(
+					`gh-${issue.data.number}-${msg.channel.id}`
+				);
+			}
+		}
+	}
+}

--- a/src/listener/githubIssueReference.ts
+++ b/src/listener/githubIssueReference.ts
@@ -31,7 +31,7 @@ export default class GithubIssueReferenceListener extends Listener {
 					`gh-${issueNumber}-${msg.channel.id}`
 				)
 			)
-				return msg.react('⏲️');
+			return msg.react('⏲️');
 			const issue = await getIssue(
 				this.client,
 				config.features.githubIssue.githubRepoOwner,

--- a/src/structure/cacheManager.ts
+++ b/src/structure/cacheManager.ts
@@ -1,0 +1,44 @@
+import { Collection } from 'discord.js';
+
+const EXPIRED_MS = 8.64e7; // 24 hours
+
+export class CacheManager<K, V> {
+	private store: Collection<K, V>;
+	private time: Collection<K, Date | number>;
+
+	constructor() {
+		this.store = new Collection();
+		this.time = new Collection();
+	}
+
+	isInCache(key: K) {
+		if (this.store.has(key)) return true;
+		return false;
+	}
+
+	getValue(key: K) {
+		if (this.store.has(key) && this.time.has(key)) return this.store.get(key);
+		return null;
+	}
+
+	getLastUpdate(key: K) {
+		if (this.time.has(key) && this.store.has(key)) return this.time.get(key);
+		return null;
+	}
+
+	addIssue(key: K, value: V) {
+		this.store.set(key, value);
+		this.time.set(key, Date.now());
+		setTimeout(() => this.removeIssue(key), EXPIRED_MS);
+	}
+
+	removeIssue(key: K) {
+		if (this.store.delete(key) && this.time.delete(key)) return true;
+		return false;
+	}
+
+	getType() {
+		if (typeof this.store === typeof this.time) return typeof this.store;
+		return null;
+	}
+}

--- a/src/structure/cacheManager.ts
+++ b/src/structure/cacheManager.ts
@@ -1,6 +1,6 @@
 import { Collection } from 'discord.js';
 
-const EXPIRED_MS = 6e5; // 10 minutes
+const EXPIRED_MS = 600000; // 10 minutes
 
 export class CacheManager<K, V> {
 	private store: Collection<K, V>;

--- a/src/structure/cacheManager.ts
+++ b/src/structure/cacheManager.ts
@@ -1,6 +1,6 @@
 import { Collection } from 'discord.js';
 
-const EXPIRED_MS = 8.64e7; // 24 hours
+const EXPIRED_MS = 6e5; // 10 minutes
 
 export class CacheManager<K, V> {
 	private store: Collection<K, V>;

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -229,6 +229,7 @@ export async function generateHastebinFromInput(input: string, ext: string) {
 		throw new Error(`Error while generating hastebin: ${res.statusText}`);
 	const { key }: { key: string } = await res.json();
 	return `${HASTEBIN_URI}/${key}.${ext}`;
+}
 
 const octokit = new Octokit();
 export async function getIssue(

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,103 @@
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+"@octokit/auth-token@^2.4.0":
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.3.tgz#b868b5f2366533a7e62933eaa1181a8924228cc4"
+  integrity sha512-fdGoOQ3kQJh+hrilc0Plg50xSfaCKOeYN9t6dpJKXN9BxhhfquL0OzoQXg3spLYymL5rm29uPeI3KEXRaZQ9zg==
+  dependencies:
+    "@octokit/types" "^5.0.0"
+
+"@octokit/core@^3.0.0":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.2.1.tgz#9e04df3f4e7f825ac0559327490ce34299140af5"
+  integrity sha512-XfFSDDwv6tclUenS0EmB6iA7u+4aOHBT1Lz4PtQNQQg3hBbNaR/+Uv5URU+egeIuuGAiMRiDyY92G4GBOWOqDA==
+  dependencies:
+    "@octokit/auth-token" "^2.4.0"
+    "@octokit/graphql" "^4.3.1"
+    "@octokit/request" "^5.4.0"
+    "@octokit/types" "^5.0.0"
+    before-after-hook "^2.1.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.9.tgz#c6a772e024202b1bd19ab69f90e0536a2598b13e"
+  integrity sha512-3VPLbcCuqji4IFTclNUtGdp9v7g+nspWdiCUbK3+iPMjJCZ6LEhn1ts626bWLOn0GiDb6j+uqGvPpqLnY7pBgw==
+  dependencies:
+    "@octokit/types" "^5.0.0"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.3.1":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.7.tgz#f4562dcd9e80ea94602068e85aefac19a88f8578"
+  integrity sha512-Gk0AR+DcwIK/lK/GX+OQ99UqtenQhcbrhHHfOYlrCQe17ADnX3EKAOKRsAZ9qZvpi5MuwWm/Nm+9aO2kTDSdyA==
+  dependencies:
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/plugin-paginate-rest@^2.2.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.0.tgz#03416396e7a227b268c5b827365238f620a9c5c1"
+  integrity sha512-o+O8c1PqsC5++BHXfMZabRRsBIVb34tXPWyQLyp2IXq5MmkxdipS7TXM4Y9ldL1PzY9CTrCsn/lzFFJGM3oRRA==
+  dependencies:
+    "@octokit/types" "^5.5.0"
+
+"@octokit/plugin-request-log@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz#394d59ec734cd2f122431fbaf05099861ece3c44"
+  integrity sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==
+
+"@octokit/plugin-rest-endpoint-methods@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.1.tgz#8224833a45c3394836dc6e86f1e6c49269a2c350"
+  integrity sha512-QyFr4Bv807Pt1DXZOC5a7L5aFdrwz71UHTYoHVajYV5hsqffWm8FUl9+O7nxRu5PDMtB/IKrhFqTmdBTK5cx+A==
+  dependencies:
+    "@octokit/types" "^5.5.0"
+    deprecation "^2.3.1"
+
+"@octokit/request-error@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.3.tgz#b51b200052bf483f6fa56c9e7e3aa51ead36ecd8"
+  integrity sha512-GgD5z8Btm301i2zfvJLk/mkhvGCdjQ7wT8xF9ov5noQY8WbKZDH9cOBqXzoeKd1mLr1xH2FwbtGso135zGBgTA==
+  dependencies:
+    "@octokit/types" "^5.0.1"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.0":
+  version "5.4.10"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.10.tgz#402d2c53768bde12b99348329ba4129746aebb9c"
+  integrity sha512-egA49HkqEORVGDZGav1mh+VD+7uLgOxtn5oODj6guJk0HCy+YBSYapFkSLFgeYj3Fr18ZULKGURkjyhkAChylw==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^5.0.0"
+    deprecation "^2.0.0"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    once "^1.4.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^18.0.7":
+  version "18.0.9"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.0.9.tgz#964d707d914eb34b1787895fdcacff96de47844d"
+  integrity sha512-CC5+cIx974Ygx9lQNfUn7/oXDQ9kqGiKUC6j1A9bAVZZ7aoTF8K6yxu0pQhQrLBwSl92J6Z3iVDhGhGFgISCZg==
+  dependencies:
+    "@octokit/core" "^3.0.0"
+    "@octokit/plugin-paginate-rest" "^2.2.0"
+    "@octokit/plugin-request-log" "^1.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "4.2.1"
+
+"@octokit/types@^5.0.0", "@octokit/types@^5.0.1", "@octokit/types@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.5.0.tgz#e5f06e8db21246ca102aa28444cdb13ae17a139b"
+  integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
+  dependencies:
+    "@types/node" ">= 8"
+
 "@sentry/apm@5.19.1":
   version "5.19.1"
   resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.19.1.tgz#cdd1d68075b2c904473d32b8e933ad292c2e3628"
@@ -157,6 +254,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.2.tgz#160d82623610db590a64e8ca81784e11117e5a54"
   integrity sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==
 
+"@types/node@>= 8":
+  version "14.14.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
+  integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
+
 "@types/node@^13.13.0":
   version "13.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.0.tgz#30d2d09f623fe32cde9cb582c7a6eda2788ce4a8"
@@ -188,6 +290,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+before-after-hook@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
+  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
 bl@^2.2.0:
   version "2.2.1"
@@ -252,6 +359,11 @@ denque@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
   integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
+
+deprecation@^2.0.0, deprecation@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -320,6 +432,11 @@ inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -452,6 +569,13 @@ numeral@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/numeral/-/numeral-2.0.6.tgz#4ad080936d443c2561aed9f2197efffe25f4e506"
   integrity sha1-StCAk21EPCVhrtnyGX7//iX05QY=
+
+once@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
 
 parse-duration@jellz/parse-duration:
   version "0.4.4"
@@ -608,10 +732,20 @@ typescript@^3.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 ws@^7.2.1:
   version "7.2.3"


### PR DESCRIPTION
Closes [#25](https://github.com/Minehut/Meta/issues/25)

- When you type #(number) it sends an embed containing a truncated version of that github issue. It removes checklists and random whitespace to make the embed as informative as possible.  
- implements a cache feature which saves the issue information locally for 10 minutes (deletes after that time) to limit the number of API requests the bot is doing.
- implements a cooldown with the already existing cooldown manager to prevent spam, etc.
- guild config for ignored channels + repo info.

Hopefully, I didn't butcher this... but again thanks to @jellz for helping :)