### PR TITLE
Add force-revoke to boosterpass description

### DIFF
--- a/src/command/boosterPass/boosterPass.ts
+++ b/src/command/boosterPass/boosterPass.ts
@@ -13,7 +13,8 @@ export default class BoosterPassCommand extends MinehutCommand {
                 Available subcommands:
                 • **give** \`<member>\`
                 • **info** \`<member>\`
-                • **revoke** \`<member>\`
+				• **revoke** \`<member>\`
+				• **force-revoke** \`<member>\` \`<user>\`
                 `,
 				usage: '<method> <...arguments>',
 				examples: [
@@ -23,6 +24,8 @@ export default class BoosterPassCommand extends MinehutCommand {
 					'info 535986058991501323',
 					'revoke @Facto',
 					'revoke 535986058991501323',
+					'force-revoke @jellz @ronthecookie',
+					'force-revoke 399406110261641216 142244934139904000'
 				],
 			},
 			category: 'boosterpass',


### PR DESCRIPTION
Adds the `force-revoke` sub command to the booster pass example and lists it under available sub commands.