### PR TITLE
Apply character limit to server properties (again)

### DIFF
--- a/src/command/info/server.ts
+++ b/src/command/info/server.ts
@@ -63,7 +63,7 @@ export default class ServerInfoCommand extends MinehutCommand {
 									? 'Yes'
 									: 'No'
 								: server.serverProperties[key].toString().length > 0
-								? `\`${server.serverProperties[key]}\``
+								? `\`${truncate(server.serverProperties[key], { length: 50 })}\``
 								: truncate(server.serverProperties[key]+"", { length: 50 })
 						}`
 				),

--- a/src/command/info/server.ts
+++ b/src/command/info/server.ts
@@ -63,7 +63,7 @@ export default class ServerInfoCommand extends MinehutCommand {
 									? 'Yes'
 									: 'No'
 								: server.serverProperties[key].toString().length > 0
-								? `\`${truncate(server.serverProperties[key], { length: 50 })}\``
+								? `\`${truncate(server.serverProperties[key]+"", { length: 50 })}\``
 								: truncate(server.serverProperties[key]+"", { length: 50 })
 						}`
 				),


### PR DESCRIPTION
Goofed last time where I didn't apply the truncate method to all instances. This pr does that