### PR TITLE
Add common invite whitelist to meta

### DIFF
--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -152,6 +152,7 @@ guildConfigs.set('546414872196415501', {
 			prefix: '',
 		},
 		censor: {
+			inviteWhitelist: INVITE_WHITELIST,
 			allowSwearing: true,
 			minimumChatPermission: PermissionLevel.Everyone,
 			overrides: [],


### PR DESCRIPTION
Add the common invite whitelist that the main discord guild uses to meta so invites such as the main Minehut discord aren't blocked.