### PR TITLE
Fix boosterpasses not getting revoked on unboost

### DIFF
--- a/src/model/boosterPass.ts
+++ b/src/model/boosterPass.ts
@@ -74,7 +74,7 @@ export class BoosterPass {
 					boosterPassReceiver
 				);
 				if (
-					receiverReceivedPasses.length < 0 &&
+					receiverReceivedPasses.length <= 0 &&
 					boosterPassReceiver.roles.cache.has(boosterPassRole)
 				)
 					boosterPassReceiver.roles.remove(boosterPassRole);


### PR DESCRIPTION
Modifies the check for received booster passes to be less than or equal to zero rather than less than zero so the booster pass role can be revoked when revoking all granted booster passes of a member.