### PR TITLE
Default member arg on boosterpass info

### DIFF
--- a/src/command/boosterPass/info.ts
+++ b/src/command/boosterPass/info.ts
@@ -21,11 +21,7 @@ export default class BoosterInfoCommand extends MinehutCommand {
 				{
 					id: 'member',
 					type: 'member',
-					prompt: {
-						start: (msg: Message) =>
-							`${msg.author}, whose booster passes should I look up?`,
-						retry: (msg: Message) => `${msg.author}, please mention a member.`,
-					},
+					default: (msg: Message) => msg.member,
 				},
 			],
 		});


### PR DESCRIPTION
Rather than prompting a user to input a member to lookup when none is inputted, just substitute the member arg for the user instead to look up their boosterpass information. I often see people in the boosterpass-cmds channel mentioning themselves to lookup their own boosterpass, this would remove that inconvenience. 