### PR TITLE
Create multiple aliases for boosterpass commands

### DIFF
--- a/src/command/boosterPass/boosterPass.ts
+++ b/src/command/boosterPass/boosterPass.ts
@@ -36,10 +36,10 @@ export default class BoosterPassCommand extends MinehutCommand {
 	*args() {
 		const method = yield {
 			type: [
-				['boosterpass-give', 'give'],
-				['boosterpass-revoke', 'revoke'],
+				['boosterpass-give', 'give', 'grant'],
+				['boosterpass-revoke', 'revoke', 'remove'],
 				['boosterpass-info', 'info'],
-				['boosterpass-force-revoke', 'force-revoke']
+				['boosterpass-force-revoke', 'force-revoke', 'force-remove']
 			],
 			otherwise: (msg: Message) => {
 				const prefix = (this.handler.prefix as PrefixSupplier)(msg) as string;


### PR DESCRIPTION
Adds the following aliases to their respective commands:

* boosterpass-give - `grant`
* boosterpass-revoke - `remove`
* boosterpass-force-revoke - `force-remove`