### PR TITLE
Make the cacheManager more 'resuable'

### DIFF
--- a/src/client/minehutClient.ts
+++ b/src/client/minehutClient.ts
@@ -105,7 +105,7 @@ export class MinehutClient extends AkairoClient {
 		this.hastebinCooldownManager = new CooldownManager(10000);
 		this.githubCooldownManager = new CooldownManager(10000);
 
-		this.githubCacheManager = new CacheManager();
+		this.githubCacheManager = new CacheManager(600000);
 
 		this.minehutApi = new Minehut();
 

--- a/src/structure/cacheManager.ts
+++ b/src/structure/cacheManager.ts
@@ -1,12 +1,15 @@
 import { Collection } from 'discord.js';
 
-const EXPIRED_MS = 600000; // 10 minutes
-
+/* 
+	This class can be used to manage caches for anything;
+	It was originally created to manage the cache for github issue referencing
+	But it is written in a way that it can be initialised and used to manage any cache
+*/
 export class CacheManager<K, V> {
 	private store: Collection<K, V>;
 	private time: Collection<K, Date | number>;
 
-	constructor() {
+	constructor(private readonly expiredMS: number) {
 		this.store = new Collection();
 		this.time = new Collection();
 	}
@@ -26,19 +29,19 @@ export class CacheManager<K, V> {
 		return null;
 	}
 
-	addIssue(key: K, value: V) {
+	addValue(key: K, value: V) {
 		this.store.set(key, value);
 		this.time.set(key, Date.now());
-		setTimeout(() => this.removeIssue(key), EXPIRED_MS);
+		setTimeout(() => this.removeValue(key), this.expiredMS);
 	}
 
-	removeIssue(key: K) {
+	removeValue(key: K) {
 		if (this.store.delete(key) && this.time.delete(key)) return true;
 		return false;
 	}
 
 	getType() {
-		if (typeof this.store === typeof this.time) return typeof this.store;
+		if (typeof this.store) return typeof this.store;
 		return null;
 	}
 }

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -273,7 +273,7 @@ export async function getIssue(
 			issue_number: issueNumber,
 		});
 		if (issue.data.pull_request) return null;
-		client.githubCacheManager.addIssue(issueNumber, issue);
+		client.githubCacheManager.addValue(issueNumber, issue);
 		return issue;
 	} catch {
 		return null;


### PR DESCRIPTION
Made the cache manager more 'reusable' so if someone were to use it again, it would be easier for them.
- Changed name of the method 'addIssue'
- Add comment
- Make the expiration time an argument in the constructor.
- a few others things