### PR TITLE
Add starboard configuration for main discord

### DIFF
--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -79,6 +79,17 @@ guildConfigs.set('239599059415859200', {
 		hastebinConversion: {
 			ignoredChannels: ['480889821225549824'],
 			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
+		},
+		starboard: {
+			channel: '805566446527709244',
+			triggerAmount: 5,
+			minimumPermLevel: PermissionLevel.Helper,
+			ignoredChannels: [
+				'412394499919052810', // #support
+				'364448476458778625', // #marketplace
+				'240274910688051211', // #servers
+				'480888099547774976', // #staff
+			]
 		}
 	},
 });


### PR DESCRIPTION
Adds starboard configuration for the main discord:

* A minimum of 5 ⭐ reactions are required as well as a helper+ reacting to the message to end up on the starboard.
* Ignores channels:
  * `#servers`
  * `#marketplace`
  * `#support`
  * `#staff`