### PR TITLE
Add auto react to cfaq-suggestions

### DIFF
--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -180,6 +180,12 @@ guildConfigs.set('546414872196415501', {
 					allowMessageAuthorReacting: false,
 					allowMultipleUserReactions: false,
 				},
+				{
+					channel: '808144433698570250',
+					reactions: [':yes:546435721444196353', ':no:546435753719103488'],
+					allowMessageAuthorReacting: false,
+					allowMultipleUserReactions: false
+				}
 			],
 		},
 		hastebinConversion: {


### PR DESCRIPTION
Adds auto reactions to the `#cfaq-suggestions` channel in meta. 