### PR TITLE
Channel Lockdown Command

### DIFF
--- a/src/client/minehutClientEvents.ts
+++ b/src/client/minehutClientEvents.ts
@@ -15,6 +15,8 @@ export default interface MinehutClientEvents extends ClientEvents {
 	channelCooldownSet: [TextChannel, GuildMember, number];
 	boosterPassGrant: [GuildMember, GuildMember];
 	boosterPassRevoke: [GuildMember, DocumentType<BoosterPass>];
+	channelLocked: [GuildMember, TextChannel[]];
+	channelUnlocked: [GuildMember, TextChannel[]];
 }
 
 export type MinehutClientEvent = keyof MinehutClientEvents;

--- a/src/command/mod/lock.ts
+++ b/src/command/mod/lock.ts
@@ -5,10 +5,10 @@ import { MinehutCommand } from '../../structure/command/minehutCommand';
 import { MESSAGES } from '../../util/constants';
 import { PermissionLevel } from '../../util/permission/permissionLevel';
 
-export default class ChannelLockdownCommand extends MinehutCommand {
+export default class ChannelLockCommand extends MinehutCommand {
 	constructor() {
-		super('lockdown', {
-			aliases: ['lockdown', 'lock'],
+		super('lock', {
+			aliases: ['lock'],
 			category: 'mod',
 			channel: 'guild',
 			clientPermissions: ['MANAGE_CHANNELS'],
@@ -78,23 +78,24 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 				);
 				lockedChannels.push(channel);
 			}
-		}
-		const differenceOfLengthAndLocked = channels.length - lockedChannels.length;
-		const m = await msg.channel.send(
-			`${process.env.EMOJI_CHECK} locked **${lockedChannels.length}** ${
-				lockedChannels.length == 1 ? 'channel' : 'channels'
-			} ${
-				differenceOfLengthAndLocked != 0
-					? `(**${differenceOfLengthAndLocked}** ${
-							differenceOfLengthAndLocked == 1 ? 'channel' : 'channels'
-					  } already locked)`
-					: ''
-			}`
-		);
-		this.client.emit('channelLocked', msg.member!, lockedChannels);
-		if (channels.some(c => c.id === msg.channel.id)) {
-			await msg.delete();
-			setTimeout(async () => await m.delete(), 3000);
+			const differenceOfLengthAndLocked =
+				channels.length - lockedChannels.length;
+			const m = await msg.channel.send(
+				`${process.env.EMOJI_CHECK} locked **${lockedChannels.length}** ${
+					lockedChannels.length == 1 ? 'channel' : 'channels'
+				} ${
+					differenceOfLengthAndLocked != 0
+						? `(**${differenceOfLengthAndLocked}** ${
+								differenceOfLengthAndLocked == 1 ? 'channel' : 'channels'
+						  } already locked)`
+						: ''
+				}`
+			);
+			this.client.emit('channelLocked', msg.member!, lockedChannels);
+			if (channels.some(c => c.id === msg.channel.id)) {
+				await msg.delete();
+				setTimeout(async () => await m.delete(), 3000);
+			}
 		}
 	}
 }

--- a/src/command/mod/lock.ts
+++ b/src/command/mod/lock.ts
@@ -59,7 +59,7 @@ export default class ChannelLockCommand extends MinehutCommand {
 			}
 		}
 		if (channels.length == 0)
-			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'lockdown'));
+			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'lock'));
 		const lockedChannels = [];
 		for (const channel of channels) {
 			const permissions = channel.permissionsFor(msg.guild!.roles.everyone);

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -16,7 +16,11 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 			description: {
 				content: 'Lockdown a channel or a set of channels',
 				usage: '[...channels] [-all]',
-				examples: ['364502598805356545 412394499919052810', '-all'],
+				examples: [
+					'364502598805356545 412394499919052810',
+					'-all',
+					'412394499919052810 -all',
+				],
 			},
 			args: [
 				{

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -1,0 +1,94 @@
+import { PrefixSupplier } from 'discord-akairo';
+import { Message, Permissions, TextChannel } from 'discord.js';
+import { guildConfigs } from '../../guild/config/guildConfigs';
+import { MinehutCommand } from '../../structure/command/minehutCommand';
+import { MESSAGES } from '../../util/constants';
+import { PermissionLevel } from '../../util/permission/permissionLevel';
+
+export default class ChannelLockdownCommand extends MinehutCommand {
+	constructor() {
+		super('lockdown', {
+			aliases: ['lockdown', 'lock'],
+			category: 'mod',
+			channel: 'guild',
+			clientPermissions: ['MANAGE_CHANNELS'],
+			permissionLevel: PermissionLevel.Moderator,
+			description: {
+				content: 'Lockdown a channel or a set of channels',
+				usage: '[...channels] [-all]',
+				examples: ['364502598805356545 412394499919052810', '-all'],
+			},
+			args: [
+				{
+					id: 'channels',
+					type: 'textChannel',
+					match: 'separate',
+					default: [],
+				},
+				{
+					id: 'allChannels',
+					match: 'flag',
+					flag: '-all',
+				},
+			],
+		});
+	}
+
+	async exec(
+		msg: Message,
+		{ channels, allChannels }: { channels: TextChannel[]; allChannels: boolean }
+	) {
+		const prefix = (this.handler.prefix as PrefixSupplier)(msg) as string;
+		const guildConfig = guildConfigs.get(msg.guild!.id);
+		if (allChannels) {
+			const channelLockdownConfig = guildConfig?.features.channelLockdown;
+			if (!channelLockdownConfig)
+				return msg.channel.send(
+					`${process.env.EMOJI_CROSS} Cannot use flag \`-all\` as channel lockdown is not configured for this guild.`
+				);
+			for (const channel of channelLockdownConfig.channels) {
+				if (!channels.some(c => c.id === channel))
+					channels.push(this.client.channels.resolve(channel) as TextChannel);
+			}
+		}
+		if (channels.length == 0)
+			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'lockdown'));
+		let lockedChannels = 0;
+		for (const channel of channels) {
+			if (
+				!channel.permissionOverwrites.some(
+					permissionOverwrite =>
+						permissionOverwrite.id === msg.guild!.roles.everyone.id &&
+						permissionOverwrite.deny.equals(
+							Permissions.FLAGS.SEND_MESSAGES + Permissions.FLAGS.ADD_REACTIONS
+						)
+				)
+			) {
+				await channel.overwritePermissions([
+					...channel.permissionOverwrites.array(),
+					{
+						id: msg.guild!.roles.everyone,
+						deny: ['SEND_MESSAGES', 'ADD_REACTIONS'],
+					},
+				]);
+				lockedChannels++;
+			}
+		}
+		const differenceOfLengthAndLocked = channels.length - lockedChannels;
+		const m = await msg.channel.send(
+			`${process.env.EMOJI_CHECK} locked **${lockedChannels}** ${
+				lockedChannels == 1 ? 'channel' : 'channels'
+			} ${
+				differenceOfLengthAndLocked != 0
+					? `(**${differenceOfLengthAndLocked}** ${
+							differenceOfLengthAndLocked == 1 ? 'channel' : 'channels'
+					  } already locked)`
+					: ''
+			}`
+		);
+		if (channels.some(c => c.id === msg.channel.id)) {
+			await msg.delete();
+			setTimeout(async () => await m.delete(), 3000);
+		}
+	}
+}

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -47,8 +47,11 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 					`${process.env.EMOJI_CROSS} Cannot use flag \`-all\` as channel lockdown is not configured for this guild.`
 				);
 			for (const channel of channelLockdownConfig.channels) {
-				if (!channels.some(c => c.id === channel))
-					channels.push(this.client.channels.resolve(channel) as TextChannel);
+				if (!channels.some(c => c.id === channel)) {
+					const resolvedChannel = this.client.channels.resolve(channel);
+					if (resolvedChannel && resolvedChannel.type == 'text')
+						channels.push(resolvedChannel as TextChannel);
+				}
 			}
 		}
 		if (channels.length == 0)

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -63,11 +63,7 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 		const lockedChannels = [];
 		for (const channel of channels) {
 			const permissions = channel.permissionsFor(msg.guild!.roles.everyone);
-			if (
-				permissions &&
-				permissions.toArray().includes('SEND_MESSAGES') &&
-				permissions.toArray().includes('ADD_REACTIONS')
-			) {
+			if (permissions && permissions.toArray().includes('SEND_MESSAGES')) {
 				await channel.updateOverwrite(
 					msg.guild!.roles.everyone,
 					{

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -1,5 +1,5 @@
 import { PrefixSupplier } from 'discord-akairo';
-import { Message, Permissions, TextChannel } from 'discord.js';
+import { Message, TextChannel } from 'discord.js';
 import { guildConfigs } from '../../guild/config/guildConfigs';
 import { MinehutCommand } from '../../structure/command/minehutCommand';
 import { MESSAGES } from '../../util/constants';
@@ -62,22 +62,20 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'lockdown'));
 		const lockedChannels = [];
 		for (const channel of channels) {
+			const permissions = channel.permissionsFor(msg.guild!.roles.everyone);
 			if (
-				!channel.permissionOverwrites.some(
-					permissionOverwrite =>
-						permissionOverwrite.id === msg.guild!.roles.everyone.id &&
-						permissionOverwrite.deny.equals(
-							Permissions.FLAGS.SEND_MESSAGES + Permissions.FLAGS.ADD_REACTIONS
-						)
-				)
+				permissions &&
+				permissions.toArray().includes('SEND_MESSAGES') &&
+				permissions.toArray().includes('ADD_REACTIONS')
 			) {
-				await channel.overwritePermissions([
-					...channel.permissionOverwrites.array(),
+				await channel.updateOverwrite(
+					msg.guild!.roles.everyone,
 					{
-						id: msg.guild!.roles.everyone,
-						deny: ['SEND_MESSAGES', 'ADD_REACTIONS'],
+						SEND_MESSAGES: false,
+						ADD_REACTIONS: false,
 					},
-				]);
+					`Channel lock from ${msg.author.tag}`
+				);
 				lockedChannels.push(channel);
 			}
 		}

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -5,10 +5,10 @@ import { MinehutCommand } from '../../structure/command/minehutCommand';
 import { MESSAGES } from '../../util/constants';
 import { PermissionLevel } from '../../util/permission/permissionLevel';
 
-export default class ChannelLockCommand extends MinehutCommand {
+export default class ChannelLockdownCommand extends MinehutCommand {
 	constructor() {
-		super('lock', {
-			aliases: ['lock'],
+		super('lockdown', {
+			aliases: ['lockdown', 'lock'],
 			category: 'mod',
 			channel: 'guild',
 			clientPermissions: ['MANAGE_CHANNELS'],
@@ -59,7 +59,7 @@ export default class ChannelLockCommand extends MinehutCommand {
 			}
 		}
 		if (channels.length == 0)
-			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'lock'));
+			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'lockdown'));
 		const lockedChannels = [];
 		for (const channel of channels) {
 			const permissions = channel.permissionsFor(msg.guild!.roles.everyone);
@@ -78,24 +78,23 @@ export default class ChannelLockCommand extends MinehutCommand {
 				);
 				lockedChannels.push(channel);
 			}
-			const differenceOfLengthAndLocked =
-				channels.length - lockedChannels.length;
-			const m = await msg.channel.send(
-				`${process.env.EMOJI_CHECK} locked **${lockedChannels.length}** ${
-					lockedChannels.length == 1 ? 'channel' : 'channels'
-				} ${
-					differenceOfLengthAndLocked != 0
-						? `(**${differenceOfLengthAndLocked}** ${
-								differenceOfLengthAndLocked == 1 ? 'channel' : 'channels'
-						  } already locked)`
-						: ''
-				}`
-			);
-			this.client.emit('channelLocked', msg.member!, lockedChannels);
-			if (channels.some(c => c.id === msg.channel.id)) {
-				await msg.delete();
-				setTimeout(async () => await m.delete(), 3000);
-			}
+		}
+		const differenceOfLengthAndLocked = channels.length - lockedChannels.length;
+		const m = await msg.channel.send(
+			`${process.env.EMOJI_CHECK} locked **${lockedChannels.length}** ${
+				lockedChannels.length == 1 ? 'channel' : 'channels'
+			} ${
+				differenceOfLengthAndLocked != 0
+					? `(**${differenceOfLengthAndLocked}** ${
+							differenceOfLengthAndLocked == 1 ? 'channel' : 'channels'
+					  } already locked)`
+					: ''
+			}`
+		);
+		this.client.emit('channelLocked', msg.member!, lockedChannels);
+		if (channels.some(c => c.id === msg.channel.id)) {
+			await msg.delete();
+			setTimeout(async () => await m.delete(), 3000);
 		}
 	}
 }

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -53,7 +53,7 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 		}
 		if (channels.length == 0)
 			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'lockdown'));
-		let lockedChannels = 0;
+		const lockedChannels = [];
 		for (const channel of channels) {
 			if (
 				!channel.permissionOverwrites.some(
@@ -71,13 +71,13 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 						deny: ['SEND_MESSAGES', 'ADD_REACTIONS'],
 					},
 				]);
-				lockedChannels++;
+				lockedChannels.push(channel);
 			}
 		}
-		const differenceOfLengthAndLocked = channels.length - lockedChannels;
+		const differenceOfLengthAndLocked = channels.length - lockedChannels.length;
 		const m = await msg.channel.send(
-			`${process.env.EMOJI_CHECK} locked **${lockedChannels}** ${
-				lockedChannels == 1 ? 'channel' : 'channels'
+			`${process.env.EMOJI_CHECK} locked **${lockedChannels.length}** ${
+				lockedChannels.length == 1 ? 'channel' : 'channels'
 			} ${
 				differenceOfLengthAndLocked != 0
 					? `(**${differenceOfLengthAndLocked}** ${
@@ -86,6 +86,7 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 					: ''
 			}`
 		);
+		this.client.emit('channelLocked', msg.member!, lockedChannels);
 		if (channels.some(c => c.id === msg.channel.id)) {
 			await msg.delete();
 			setTimeout(async () => await m.delete(), 3000);

--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -14,7 +14,8 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 			clientPermissions: ['MANAGE_CHANNELS'],
 			permissionLevel: PermissionLevel.Moderator,
 			description: {
-				content: 'Lockdown a channel or a set of channels (MUST USE QUOTES FOR REASON FLAG)',
+				content:
+					'Lockdown a channel or a set of channels (MUST USE QUOTES FOR REASON FLAG)',
 				usage: '[...channels] [-all] [reason:""]',
 				examples: [
 					'364502598805356545 412394499919052810',
@@ -87,7 +88,7 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 					const embed = new MessageEmbed()
 						.setTitle('This channel has been locked!')
 						.setDescription(reason)
-						.setColor('BLUE')
+						.setColor('BLUE');
 					channel.send(embed);
 				}
 				lockedChannels.push(channel);

--- a/src/command/mod/unlock.ts
+++ b/src/command/mod/unlock.ts
@@ -47,8 +47,11 @@ export default class UnlockChannelCommand extends MinehutCommand {
 					`${process.env.EMOJI_CROSS} Cannot use flag \`-all\` as channel lockdown is not configured for this guild.`
 				);
 			for (const channel of channelLockdownConfig.channels) {
-				if (!channels.some(c => c.id === channel))
-					channels.push(this.client.channels.resolve(channel) as TextChannel);
+				if (!channels.some(c => c.id === channel)) {
+					const resolvedChannel = this.client.channels.resolve(channel);
+					if (resolvedChannel && resolvedChannel.type == 'text')
+						channels.push(resolvedChannel as TextChannel);
+				}
 			}
 		}
 		if (channels.length == 0)

--- a/src/command/mod/unlock.ts
+++ b/src/command/mod/unlock.ts
@@ -1,0 +1,94 @@
+import { PrefixSupplier } from 'discord-akairo';
+import { Message, Permissions, TextChannel } from 'discord.js';
+import { guildConfigs } from '../../guild/config/guildConfigs';
+import { MinehutCommand } from '../../structure/command/minehutCommand';
+import { MESSAGES } from '../../util/constants';
+import { PermissionLevel } from '../../util/permission/permissionLevel';
+
+export default class UnlockChannelCommand extends MinehutCommand {
+	constructor() {
+		super('unlock', {
+			aliases: ['unlock'],
+			category: 'mod',
+			channel: 'guild',
+			clientPermissions: ['MANAGE_CHANNELS'],
+			permissionLevel: PermissionLevel.Moderator,
+			description: {
+				content: 'Unlock a channel or a set of channels',
+				usage: '[...channels] [-all]',
+				examples: ['364502598805356545 412394499919052810', '-all'],
+			},
+			args: [
+				{
+					id: 'channels',
+					type: 'textChannel',
+					match: 'separate',
+					default: [],
+				},
+				{
+					id: 'allChannels',
+					match: 'flag',
+					flag: '-all',
+				},
+			],
+		});
+	}
+
+	async exec(
+		msg: Message,
+		{ channels, allChannels }: { channels: TextChannel[]; allChannels: boolean }
+	) {
+		const prefix = (this.handler.prefix as PrefixSupplier)(msg) as string;
+		const guildConfig = guildConfigs.get(msg.guild!.id);
+		if (allChannels) {
+			const channelLockdownConfig = guildConfig?.features.channelLockdown;
+			if (!channelLockdownConfig)
+				return msg.channel.send(
+					`${process.env.EMOJI_CROSS} Cannot use flag \`-all\` as channel lockdown is not configured for this guild.`
+				);
+			for (const channel of channelLockdownConfig.channels) {
+				if (!channels.some(c => c.id === channel))
+					channels.push(this.client.channels.resolve(channel) as TextChannel);
+			}
+		}
+		if (channels.length == 0)
+			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'unlock'));
+		let unlockedChannels = 0;
+		for (const channel of channels) {
+			if (
+				channel.permissionOverwrites.some(
+					permissionOverwrite =>
+						permissionOverwrite.id === msg.guild!.roles.everyone.id &&
+						permissionOverwrite.deny.equals(
+							Permissions.FLAGS.SEND_MESSAGES + Permissions.FLAGS.ADD_REACTIONS
+						)
+				)
+			) {
+				await channel.overwritePermissions([
+					...channel.permissionOverwrites.array(),
+					{
+						id: msg.guild!.roles.everyone,
+						allow: ['SEND_MESSAGES', 'ADD_REACTIONS'],
+					},
+				]);
+				unlockedChannels++;
+			}
+		}
+		const differenceOfLengthAndUnlocked = channels.length - unlockedChannels;
+		const m = await msg.channel.send(
+			`${process.env.EMOJI_CHECK} unlocked **${unlockedChannels}** ${
+				unlockedChannels == 1 ? 'channel' : 'channels'
+			} ${
+				differenceOfLengthAndUnlocked != 0
+					? `(**${differenceOfLengthAndUnlocked}** ${
+							differenceOfLengthAndUnlocked == 1 ? 'channel' : 'channels'
+					  } already unlocked)`
+					: ''
+			}`
+		);
+		if (channels.some(c => c.id === msg.channel.id)) {
+			await msg.delete();
+			setTimeout(async () => await m.delete(), 3000);
+		}
+	}
+}

--- a/src/command/mod/unlock.ts
+++ b/src/command/mod/unlock.ts
@@ -1,5 +1,5 @@
 import { PrefixSupplier } from 'discord-akairo';
-import { Message, Permissions, TextChannel } from 'discord.js';
+import { Message, TextChannel } from 'discord.js';
 import { guildConfigs } from '../../guild/config/guildConfigs';
 import { MinehutCommand } from '../../structure/command/minehutCommand';
 import { MESSAGES } from '../../util/constants';
@@ -62,22 +62,22 @@ export default class UnlockChannelCommand extends MinehutCommand {
 			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'unlock'));
 		const unlockedChannels = [];
 		for (const channel of channels) {
+			const permissions = channel.permissionsFor(msg.guild!.roles.everyone);
 			if (
-				channel.permissionOverwrites.some(
-					permissionOverwrite =>
-						permissionOverwrite.id === msg.guild!.roles.everyone.id &&
-						permissionOverwrite.deny.equals(
-							Permissions.FLAGS.SEND_MESSAGES + Permissions.FLAGS.ADD_REACTIONS
-						)
+				!permissions ||
+				!(
+					permissions.toArray().includes('SEND_MESSAGES') &&
+					permissions.toArray().includes('ADD_REACTIONS')
 				)
 			) {
-				await channel.overwritePermissions([
-					...channel.permissionOverwrites.array(),
+				await channel.updateOverwrite(
+					msg.guild!.roles.everyone,
 					{
-						id: msg.guild!.roles.everyone,
-						allow: ['SEND_MESSAGES', 'ADD_REACTIONS'],
+						SEND_MESSAGES: null,
+						ADD_REACTIONS: null,
 					},
-				]);
+					`Channel unlock from ${msg.author.tag}`
+				);
 				unlockedChannels.push(channel);
 			}
 		}

--- a/src/command/mod/unlock.ts
+++ b/src/command/mod/unlock.ts
@@ -16,7 +16,11 @@ export default class UnlockChannelCommand extends MinehutCommand {
 			description: {
 				content: 'Unlock a channel or a set of channels',
 				usage: '[...channels] [-all]',
-				examples: ['364502598805356545 412394499919052810', '-all'],
+				examples: [
+					'364502598805356545 412394499919052810',
+					'-all',
+					'412394499919052810 -all',
+				],
 			},
 			args: [
 				{

--- a/src/command/mod/unlock.ts
+++ b/src/command/mod/unlock.ts
@@ -63,13 +63,7 @@ export default class UnlockChannelCommand extends MinehutCommand {
 		const unlockedChannels = [];
 		for (const channel of channels) {
 			const permissions = channel.permissionsFor(msg.guild!.roles.everyone);
-			if (
-				!permissions ||
-				!(
-					permissions.toArray().includes('SEND_MESSAGES') &&
-					permissions.toArray().includes('ADD_REACTIONS')
-				)
-			) {
+			if (!permissions || !permissions.toArray().includes('SEND_MESSAGES')) {
 				await channel.updateOverwrite(
 					msg.guild!.roles.everyone,
 					{

--- a/src/command/mod/unlock.ts
+++ b/src/command/mod/unlock.ts
@@ -53,7 +53,7 @@ export default class UnlockChannelCommand extends MinehutCommand {
 		}
 		if (channels.length == 0)
 			return msg.channel.send(MESSAGES.commands.useHelp(prefix, 'unlock'));
-		let unlockedChannels = 0;
+		const unlockedChannels = [];
 		for (const channel of channels) {
 			if (
 				channel.permissionOverwrites.some(
@@ -71,13 +71,14 @@ export default class UnlockChannelCommand extends MinehutCommand {
 						allow: ['SEND_MESSAGES', 'ADD_REACTIONS'],
 					},
 				]);
-				unlockedChannels++;
+				unlockedChannels.push(channel);
 			}
 		}
-		const differenceOfLengthAndUnlocked = channels.length - unlockedChannels;
+		const differenceOfLengthAndUnlocked =
+			channels.length - unlockedChannels.length;
 		const m = await msg.channel.send(
-			`${process.env.EMOJI_CHECK} unlocked **${unlockedChannels}** ${
-				unlockedChannels == 1 ? 'channel' : 'channels'
+			`${process.env.EMOJI_CHECK} unlocked **${unlockedChannels.length}** ${
+				unlockedChannels.length == 1 ? 'channel' : 'channels'
 			} ${
 				differenceOfLengthAndUnlocked != 0
 					? `(**${differenceOfLengthAndUnlocked}** ${
@@ -86,6 +87,7 @@ export default class UnlockChannelCommand extends MinehutCommand {
 					: ''
 			}`
 		);
+		this.client.emit('channelUnlocked', msg.member!, unlockedChannels);
 		if (channels.some(c => c.id === msg.channel.id)) {
 			await msg.delete();
 			setTimeout(async () => await m.delete(), 3000);

--- a/src/guild/config/feature/channelLockdown.ts
+++ b/src/guild/config/feature/channelLockdown.ts
@@ -1,0 +1,3 @@
+export interface ChannelLockdownConfiguration {
+	channels: string[];
+}

--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -1,5 +1,9 @@
 import { GuildConfiguration } from './guildConfiguration';
-import { ALL_MODLOG_EVENTS, HASTEBIN_EXTENSIONS_WHITELIST, INVITE_WHITELIST } from './common';
+import {
+	ALL_MODLOG_EVENTS,
+	HASTEBIN_EXTENSIONS_WHITELIST,
+	INVITE_WHITELIST,
+} from './common';
 import { PermissionLevel } from '../../util/permission/permissionLevel';
 
 export const guildConfigs: Map<string, GuildConfiguration> = new Map();
@@ -78,7 +82,7 @@ guildConfigs.set('239599059415859200', {
 		},
 		hastebinConversion: {
 			ignoredChannels: ['480889821225549824'],
-			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
+			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST,
 		},
 		starboard: {
 			channel: '805566446527709244',
@@ -89,8 +93,25 @@ guildConfigs.set('239599059415859200', {
 				'364448476458778625', // #marketplace
 				'240274910688051211', // #servers
 				'480888099547774976', // #staff
-			]
-		}
+			],
+		},
+		channelLockdown: {
+			channels: [
+				'364502598805356545', // #general
+				'373902459883749376', // #random
+				'412394499919052810', // #support
+				'480896531453706240', // #botcmds
+				'240274910688051211', // #servers
+				'364448476458778625', // #marketplace
+				'601544975221653514', // #count-to-1mil
+				'394312418374713344', // #mc-functions
+				'394312589754105857', // #building
+				'568531994485588007', // #art-gfx
+				'400170127737356299', // #skript
+				'660337933743816724', // #code
+				'705481433996853248', // #voice
+			],
+		},
 	},
 });
 
@@ -131,7 +152,7 @@ guildConfigs.set('715281101479739543', {
 		moderator: '715281911529996430',
 		seniorModerator: '715281850385301616',
 		manager: '732327323780513902',
-		admin: '715281797017108531'
+		admin: '715281797017108531',
 	},
 	features: {
 		modLog: {
@@ -181,20 +202,20 @@ guildConfigs.set('546414872196415501', {
 					allowMultipleUserReactions: false,
 				},
 				{
-					channel: '808144433698570250',
+					channel: '808144433698570250', // #cfaq-suggestions
 					reactions: [':yes:546435721444196353', ':no:546435753719103488'],
 					allowMessageAuthorReacting: false,
-					allowMultipleUserReactions: false
-				}
+					allowMultipleUserReactions: false,
+				},
 			],
 		},
 		hastebinConversion: {
 			ignoredChannels: ['548317804076597249'],
-			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST
-    },
+			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST,
+		},
 		githubIssue: {
-			githubRepoOwner: "Minehut",
-			githubRepoName: "Meta",
+			githubRepoOwner: 'Minehut',
+			githubRepoName: 'Meta',
 		},
 	},
 });

--- a/src/guild/config/guildConfiguration.ts
+++ b/src/guild/config/guildConfiguration.ts
@@ -8,6 +8,7 @@ import { AutoReactConfiguration } from './feature/autoReact';
 import { BoosterPassConfiguration } from './feature/boosterPass';
 import { HastebinConversionConfiguration } from './feature/hastbinConversion';
 import { GithubIssueReferenceConfiguration } from './feature/githubIssue';
+import { ChannelLockdownConfiguration } from './feature/channelLockdown';
 
 // The GuildConfiguration can have settings about permissions, log channels, disabled features, etc.
 export interface GuildConfiguration {
@@ -25,5 +26,6 @@ export interface GuildConfiguration {
 		boosterPass?: BoosterPassConfiguration;
 		hastebinConversion?: HastebinConversionConfiguration;
 		githubIssue?: GithubIssueReferenceConfiguration;
+		channelLockdown?: ChannelLockdownConfiguration;
 	};
 }

--- a/src/listener/modLog/channelLocked.ts
+++ b/src/listener/modLog/channelLocked.ts
@@ -1,0 +1,25 @@
+import { Listener } from 'discord-akairo';
+import { GuildMember, TextChannel } from 'discord.js';
+import { sendModLogMessage } from '../../util/functions';
+
+export default class ChannelLockedListener extends Listener {
+	constructor() {
+		super('channelLocked', {
+			emitter: 'client',
+			event: 'channelLocked',
+		});
+	}
+
+	async exec(member: GuildMember, channels: TextChannel[]) {
+		if (channels.length == 0) return;
+		const mappedChannels = channels.map(
+			channel => `**•** ${channel} (\`${channel.id}\`)`
+		);
+		await sendModLogMessage(
+			member.guild,
+			`:lock: ${member.user.tag} (\`${
+				member.user.id
+			}\`) locked channels: \n${mappedChannels.join('\n')}`
+		);
+	}
+}

--- a/src/listener/modLog/channelUnlocked.ts
+++ b/src/listener/modLog/channelUnlocked.ts
@@ -1,0 +1,25 @@
+import { Listener } from 'discord-akairo';
+import { GuildMember, TextChannel } from 'discord.js';
+import { sendModLogMessage } from '../../util/functions';
+
+export default class ChannelUnlocked extends Listener {
+	constructor() {
+		super('channelUnlocked', {
+			emitter: 'client',
+			event: 'channelUnlocked',
+		});
+	}
+
+	async exec(member: GuildMember, channels: TextChannel[]) {
+		if (channels.length == 0) return;
+		const mappedChannels = channels.map(
+			channel => `**•** ${channel} (\`${channel.id}\`)`
+		);
+		await sendModLogMessage(
+			member.guild,
+			`:unlock: ${member.user.tag} (\`${
+				member.user.id
+			}\`) unlocked channels: \n${mappedChannels.join('\n')}`
+		);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Minehut/Meta/issues/440

Adds two commands:
* `lock [...channels] [-all] [reason:""]` - allows a Moderator+ to lock an inputted set of channels or use the `-all` flag that populates the set of channels to lock with the ones from the guild configuration. You can optionally include a reason, if a reason exists it sends an embed to all locked channels with that reason.
* `unlock [...channels] [-all]` - works the same way as the lock command does, except it just unlocks locked channels.

Adds guild configuration:
* `ChannelLockdownConfiguration`
   * `channels` - stores an array of channels to use in correspondence with the `-all` flag.

Adds mod log events:
* `channelLocked` - emits when a channel (or a set of channels) are locked, passing the guild member who locked the channels and the channels that were locked. 
* `channelUnlocked` - emits when a channel (or a set of channels) are unlocked, passing the guild member who unlocked the channels and the channels that were unlocked.