### PR TITLE
Add section argument to 'tag set' usage

### DIFF
--- a/src/command/tag/tag.ts
+++ b/src/command/tag/tag.ts
@@ -12,7 +12,7 @@ export default class TagCommand extends MinehutCommand {
 				content: `Manage tags.
 				Available subcommands:
 				• **show** \`<name/alias>\`
-				• **set** \`<name> <content>\`
+				• **set** \`<section> <name> <content>\`
 				• **setalias** \`<alias> <target>\`
 				• **listaliases**
 				• **deletealias** \`<alias>\`


### PR DESCRIPTION
This confused me when I was trying to create a tag because the described command usage is inaccurate.