### PR TITLE
Shoot some anys

### DIFF
--- a/src/listener/missingPermissions.ts
+++ b/src/listener/missingPermissions.ts
@@ -10,7 +10,7 @@ export default class MissingPermissionsListener extends Listener {
 		});
 	}
 
-	async exec(msg: Message, _command: Command, type: string, _missing: any) {
+	async exec(msg: Message, _command: Command, type: string, _missing: unknown) {
 		if (type === 'user') msg.react('⛔');
 		else if (type === 'client') {
 			await msg.react('⛔');

--- a/src/listener/modLog/command.ts
+++ b/src/listener/modLog/command.ts
@@ -14,7 +14,7 @@ export default class ModLogCommandListener extends Listener {
 		});
 	}
 
-	async exec(msg: Message, _command: Command, _args: any[]) {
+	async exec(msg: Message, _command: Command, _args: unknown[]) {
 		if (!msg.guild) return;
 		const config = guildConfigs.get(msg.guild.id);
 		if (

--- a/src/listener/reactionRaw.ts
+++ b/src/listener/reactionRaw.ts
@@ -3,7 +3,15 @@ import { TextChannel } from 'discord.js';
 
 interface RawPacket {
 	t: string;
-	d: any;
+	d: {
+		message_id: string;
+		channel_id: string;
+		user_id: string;
+		emoji: {
+			id: string;
+			name: string;
+		}
+	};
 	s: number;
 	op: number;
 }


### PR DESCRIPTION
Using the `any` type in the codebase [is harmful](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#any) because it eliminates all type checking.

The `any` usage in the [plugin command](https://github.com/Minehut/MinehutBOT/blob/master/src/command/info/plugin.ts#L42) will be addressed in a future refactor of that command.

