### PR TITLE
Refactor plugin command + add option select

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"humanize-duration": "^3.23.0",
 		"javascript-time-ago": "^2.0.7",
 		"lodash": "^4.17.19",
-		"minehut": "^0.0.18",
+		"minehut": "^0.0.20",
 		"mongoose": "^5.11.18",
 		"node-fetch": "^2.6.1",
 		"numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"humanize-duration": "^3.23.0",
 		"javascript-time-ago": "^2.0.7",
 		"lodash": "^4.17.19",
-		"minehut": "^0.0.14",
+		"minehut": "^0.0.18",
 		"mongoose": "^5.11.18",
 		"node-fetch": "^2.6.1",
 		"numeral": "^2.0.6",

--- a/src/command/info/plugin.ts
+++ b/src/command/info/plugin.ts
@@ -91,7 +91,11 @@ export default class PluginInfoCommand extends MinehutCommand {
 
 		const embed = new MessageEmbed()
 			.setTitle(plugin.name)
-			.setDescription(extendedDescription)
+			.setDescription(
+				extendedDescription.length > 0
+					? extendedDescription
+					: plugin.description
+			)
 			.setColor(isPrivate ? 'RED' : 'BLUE')
 			.addField('Added', prettyDate(plugin.createdAt))
 			.addField('Updated', prettyDate(plugin.lastUpdatedAt), true)

--- a/src/command/info/plugin.ts
+++ b/src/command/info/plugin.ts
@@ -1,14 +1,14 @@
 import { MinehutCommand } from '../../structure/command/minehutCommand';
-import { Message, MessageEmbed } from 'discord.js';
+import { CollectorFilter, Message, MessageEmbed } from 'discord.js';
 import { prettyDate } from '../../util/functions';
-import fetch from 'node-fetch';
+import { Plugin } from 'minehut/dist/plugin/Plugin';
 
 const LINK_MATCH = /^http.*/gm;
 
 export default class PluginInfoCommand extends MinehutCommand {
 	constructor() {
 		super('pluginInfo', {
-			aliases: ['plugin'],
+			aliases: ['plugin', 'plugininfo'],
 			description: {
 				content: 'Look up a plugin on Minehut',
 				usage: '<plugin>',
@@ -17,7 +17,7 @@ export default class PluginInfoCommand extends MinehutCommand {
 			category: 'info',
 			args: [
 				{
-					id: 'pluginName',
+					id: 'query',
 					type: 'string',
 					match: 'rest',
 					prompt: {
@@ -31,46 +31,78 @@ export default class PluginInfoCommand extends MinehutCommand {
 		});
 	}
 
-	async exec(msg: Message, { pluginName }: { pluginName: string }) {
+	async exec(msg: Message, { query }: { query: string }) {
 		const m = await msg.channel.send(
-			`${process.env.EMOJI_LOADING} fetching plugin **${pluginName}**`
+			`${process.env.EMOJI_LOADING} fetching plugin **${query}**`
 		);
-		const plugins = await this.getData(
-			'https://api.minehut.com/plugins_public'
-		);
-		const plugin = plugins.all.filter(
-			(x: any) =>
-				x.name.toLowerCase() === pluginName.toLowerCase() ||
-				x._id.toLowerCase() === pluginName.toLowerCase()
-		)[0];
-		if (!plugin)
-			return m.edit(`${process.env.EMOJI_CROSS} could not fetch plugin`);
-		const link = plugin.desc_extended.match(LINK_MATCH)[0];
-		const embed: MessageEmbed = new MessageEmbed();
-		embed.setTitle(`${plugin.name}`);
-		embed.setDescription(plugin.desc);
-		embed.setColor('BLUE');
-		embed.addField('Private?', plugin.credits === 0 ? 'No' : 'Yes', true);
-		embed.addField('Disabled?', plugin.disabled ? 'Yes' : 'No', true);
-		embed.addField('Version', plugin.version, true);
-		embed.addField('File Name', plugin.file_name, true);
-		if (link) embed.addField('Plugin Link', link, true);
-		embed.addField('Created', prettyDate(new Date(plugin.created)));
-		embed.addField('Last Updated', prettyDate(new Date(plugin.last_updated)));
-		embed.setFooter(
-			`Requested by ${msg.author.tag}`,
-			msg.author.displayAvatarURL()
-		);
-		return m.edit({ content: null, embed });
-	}
 
-	async getData(url: string) {
-		try {
-			const response = await fetch(url);
-			const json = response.json();
-			return json;
-		} catch (e) {
-			if (process.env.NODE_ENV === 'development') console.log(e);
+		const plugins = await this.client.minehutApi.plugins.search(query);
+		let plugin: Plugin;
+
+		if (plugins.length < 1)
+			return m.edit(`${process.env.EMOJI_CROSS} unknown plugin`);
+		else if (plugins.length > 20) {
+			console.log(plugins.map(p => p.name));
+			return m.edit(
+				`${process.env.EMOJI_CROSS} try to narrow down your search query`
+			);
+		} else if (plugins.length === 1) plugin = plugins[0];
+		else {
+			const max = plugins.length;
+			const pluginList = plugins.map(
+				(plugin, index) => `${index + 1}) ${plugin.name}`
+			);
+
+			await m.edit(`
+			Did you mean one of these? (pick 1-${max}) \`\`\`${pluginList.join(
+				'\n'
+			)}\`\`\``);
+
+			const idFilter = <CollectorFilter>(
+				((input: Message) => msg.author.id === input.author.id)
+			);
+
+			const idMessages = await msg.channel.awaitMessages(idFilter, {
+				max: 1,
+				time: 30000,
+			});
+
+			// Delete the number message by the user
+			idMessages.forEach(m => m.delete());
+
+			const id = idMessages.map(m => Number(m.content))[0];
+			if (!id || id < 1 || id > max)
+				return m.edit(
+					`${process.env.EMOJI_CROSS} you need to specify a number between 1-${max}`
+				);
+
+			plugin = plugins[id - 1];
 		}
+
+		const extendedDescription = plugin.extendedDescription
+			.replace(/Plugin Link(:)?/gm, '')
+			.replace(LINK_MATCH, '')
+			.trim();
+
+		const match = plugin.extendedDescription.match(LINK_MATCH);
+		const link = match ? match[0] : null;
+
+		const isPrivate = plugin.credits > 0;
+
+		const embed = new MessageEmbed()
+			.setTitle(plugin.name)
+			.setDescription(extendedDescription)
+			.setColor(isPrivate ? 'RED' : 'BLUE')
+			.addField('Added', prettyDate(plugin.createdAt))
+			.addField('Updated', prettyDate(plugin.lastUpdatedAt), true)
+			.addField('Version', `\`${plugin.version}\``)
+			.setFooter(
+				`Requested by ${msg.author.tag}`,
+				msg.author.displayAvatarURL()
+			);
+
+		if (link) embed.addField('Link', link);
+
+		return m.edit({ content: null, embed });
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,10 +524,10 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.43.0"
 
-minehut@^0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/minehut/-/minehut-0.0.14.tgz#ed64cd86d3d71bbbbe2794f3253dbe041c498849"
-  integrity sha512-AwTUM8bJ9ta2E1ABKLP1WXWXNTydEEJTqi0b1u4vOw3qFQemooMlibIa8Z7ITpz2U3EimoS9nugcb456ukdwuw==
+minehut@^0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/minehut/-/minehut-0.0.18.tgz#805199ef80770082ca00c7592085bb6d235b46d6"
+  integrity sha512-DLDPw0Q2hdtIZyO8kS53N0NwZyBXWrtXrhAxvuezKAcpbYk8WhfNhWRvrNX2v6BRvantD0LBsIyuYnqWa1jsHA==
   dependencies:
     node-fetch "^2.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,10 +524,10 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.43.0"
 
-minehut@^0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/minehut/-/minehut-0.0.18.tgz#805199ef80770082ca00c7592085bb6d235b46d6"
-  integrity sha512-DLDPw0Q2hdtIZyO8kS53N0NwZyBXWrtXrhAxvuezKAcpbYk8WhfNhWRvrNX2v6BRvantD0LBsIyuYnqWa1jsHA==
+minehut@^0.0.20:
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/minehut/-/minehut-0.0.20.tgz#9747f178d218c42a0874f618463ab454bc2a28b4"
+  integrity sha512-NT0pbnB5cE/KaP5/wiuji4ms5jXtuuA4zluC8d3h2TeVG35pwnDYSK4BiD6sfp2U68mnuj140dBaPPwaBY51aA==
   dependencies:
     node-fetch "^2.6.0"
 


### PR DESCRIPTION
TL;DR This PR refactors the plugin command to improve the code, make the response message more user-friendly and add caching to improve speed and efficiency. The PR also fixes problems with resolving plugins.

- **Caching**
The current code fetches the entire plugin list every time the command is run and uses that data to find the plugin. Since this PR uses the Minehut API library, it benefits from plugin caching.

- **Typings**
The current code uses the `any` type for plugins which isn't good for type-safety and maintainability. This PR changes it to use the existing Minehut API library which includes typings for Minehut plugins. This PR also removes some unnecessary explicit typings.

- **Name searching**
Currently, the command only looks for exact (case-insensitive) matches of ID or plugin name. This is not ideal, especially when looking up plugins with special prefixes (e.g. `Skript Addon: TuSKe`). This PR [revisits the searching](https://i.imgur.com/b3uTjSY.gif), to look for exact (case-insensitive) name/ID matches first, and then look for name inclusions of the query. If the query returns multiple plugins, the bot will [let the user choose the plugin from the list](https://i.imgur.com/wihCxIe.mp4).

- **Response**
PR uses the plugin's extended description, whereas the old code only used its short description (much less descriptive). PR also omits some less important embed fields from the old code to improve UX, and the embed colour will change based on if the plugin is private or not ([red if private](https://i.imgur.com/7QR3Jag.png)). PR also renames Created to Added, to reflect that the plugin was not created on that date, but rather added to Minehut.

- **Error prone**
The old code fails if the queried plugin is missing a link in its extended description, causing the bot to just [hang](https://i.imgur.com/Oeyd6J1.png) -- that issue is [fixed here](https://i.imgur.com/k2Djhl1.png).