### PR TITLE
Fix channel lockdown not sending reason embed

### DIFF
--- a/src/command/mod/lockdown.ts
+++ b/src/command/mod/lockdown.ts
@@ -76,6 +76,13 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 		for (const channel of channels) {
 			const permissions = channel.permissionsFor(msg.guild!.roles.everyone);
 			if (permissions && permissions.toArray().includes('SEND_MESSAGES')) {
+				if (reason) {
+					const embed = new MessageEmbed()
+						.setTitle('This channel has been locked!')
+						.setDescription(reason)
+						.setColor('BLUE');
+					await channel.send(embed);
+				}
 				await channel.updateOverwrite(
 					msg.guild!.roles.everyone,
 					{
@@ -84,13 +91,6 @@ export default class ChannelLockdownCommand extends MinehutCommand {
 					},
 					`Channel lock from ${msg.author.tag}`
 				);
-				if (reason) {
-					const embed = new MessageEmbed()
-						.setTitle('This channel has been locked!')
-						.setDescription(reason)
-						.setColor('BLUE');
-					channel.send(embed);
-				}
 				lockedChannels.push(channel);
 			}
 		}


### PR DESCRIPTION
Sends the reason embed if a reason is supplied on channel lockdown before locking the channel. This is to ensure that the bot is able to send the message even if it doesn't have the correct permissions to after the channel permission overwrites are applied. 