### PR TITLE
Don't log certain events if not specified in guild config

### DIFF
--- a/src/listener/modLog/channelCooldownSet.ts
+++ b/src/listener/modLog/channelCooldownSet.ts
@@ -3,6 +3,7 @@ import { GuildMember } from 'discord.js';
 import { TextChannel } from 'discord.js';
 import { sendModLogMessage } from '../../util/functions';
 import humanizeDuration from 'humanize-duration';
+import { guildConfigs } from '../../guild/config/guildConfigs';
 
 export default class ModLogChannelCooldownSetListener extends Listener {
 	constructor() {
@@ -13,6 +14,13 @@ export default class ModLogChannelCooldownSetListener extends Listener {
 	}
 
 	async exec(channel: TextChannel, member: GuildMember, duration: number) {
+		const config = guildConfigs.get(channel.guild.id);
+		if (
+			!config ||
+			!config.features.modLog ||
+			!config.features.modLog.events.includes('channelCooldownSet')
+		)
+			return;
 		const humanizedDuration = humanizeDuration(duration, {
 			largest: 3,
 			round: true,

--- a/src/listener/modLog/channelLocked.ts
+++ b/src/listener/modLog/channelLocked.ts
@@ -1,5 +1,6 @@
 import { Listener } from 'discord-akairo';
 import { GuildMember, TextChannel } from 'discord.js';
+import { guildConfigs } from '../../guild/config/guildConfigs';
 import { sendModLogMessage } from '../../util/functions';
 
 export default class ChannelLockedListener extends Listener {
@@ -11,7 +12,14 @@ export default class ChannelLockedListener extends Listener {
 	}
 
 	async exec(member: GuildMember, channels: TextChannel[]) {
-		if (channels.length == 0) return;
+		const config = guildConfigs.get(member.guild.id);
+		if (
+			!config ||
+			!config.features.modLog ||
+			!config.features.modLog.events.includes('channelLocked') ||
+			channels.length == 0
+		)
+			return;
 		const mappedChannels = channels.map(
 			channel => `**•** ${channel} (\`${channel.id}\`)`
 		);

--- a/src/listener/modLog/channelUnlocked.ts
+++ b/src/listener/modLog/channelUnlocked.ts
@@ -1,5 +1,6 @@
 import { Listener } from 'discord-akairo';
 import { GuildMember, TextChannel } from 'discord.js';
+import { guildConfigs } from '../../guild/config/guildConfigs';
 import { sendModLogMessage } from '../../util/functions';
 
 export default class ChannelUnlocked extends Listener {
@@ -11,7 +12,14 @@ export default class ChannelUnlocked extends Listener {
 	}
 
 	async exec(member: GuildMember, channels: TextChannel[]) {
-		if (channels.length == 0) return;
+		const config = guildConfigs.get(member.guild.id);
+		if (
+			!config ||
+			!config.features.modLog ||
+			!config.features.modLog.events.includes('channelUnlocked') ||
+			channels.length == 0
+		)
+			return;
 		const mappedChannels = channels.map(
 			channel => `**•** ${channel} (\`${channel.id}\`)`
 		);


### PR DESCRIPTION
This pull request checks to see if certain events that are emitted are included in the events array specified in the mod log section of a guild config. Before this pull request, it would be impossible to ignore events:  `channelCooldownSet`, `channelLocked`, and `channelUnlocked`.