### PR TITLE
Fix unknown type for error in try-catch block

### DIFF
--- a/src/command/utility/eval.ts
+++ b/src/command/utility/eval.ts
@@ -43,7 +43,12 @@ export default class EvalCommand extends MinehutCommand {
 			if (typeof evaled !== 'string') evaled = inspect(evaled);
 			content = `\`\`\`xl\n${this.clean(evaled)}\`\`\``;
 		} catch (err) {
-			content = `\`ERROR\` \`\`\`xl\n${this.clean(err.toString())}\n\`\`\``;
+			if (err instanceof Error)
+				content = `\`ERROR\` \`\`\`xl\n${this.clean(err.toString())}\n\`\`\``;
+			else {
+				console.log(err);
+				content = `\`ERROR\` \`\`\`xl\nUnknown error\n\`\`\``;
+			}
 		}
 		if (content.length > 2000) {
 			console.log(content);


### PR DESCRIPTION
This pull request fixes the default unknown type for `err` in the try-catch block in the eval command. The variable `err` will now be checked if it is an instance of `Error` before accessing any of its properties.