### PR TITLE
disable hastebin in count channel

### DIFF
--- a/src/guild/config/guildConfigs.ts
+++ b/src/guild/config/guildConfigs.ts
@@ -77,7 +77,7 @@ guildConfigs.set('239599059415859200', {
 			maximumGrantedBoosterPasses: 2,
 		},
 		hastebinConversion: {
-			ignoredChannels: ['480889821225549824'],
+			ignoredChannels: ['480889821225549824', '601544975221653514'],
 			whitelistedExtensions: HASTEBIN_EXTENSIONS_WHITELIST,
 		},
 		starboard: {


### PR DESCRIPTION
disabled hastebin conversation feature in the #count-to-1mill channel

This is because the embed with the hastebin link it responds with doesn't get deleted and it just stays in that channel.