### PR TITLE
join number count

### DIFF
--- a/src/listener/modLog/memberJoin.ts
+++ b/src/listener/modLog/memberJoin.ts
@@ -26,7 +26,7 @@ export default class ModLogMemberJoinListener extends Listener {
 			member.guild,
 			`:inbox_tray: ${isNew ? ':new: ' : ''}${member.user.tag} (\`${
 				member.id
-			}\`) joined (account created: ${prettyDate(member.user.createdAt)})`
+			}\`) joined (account created: ${prettyDate(member.user.createdAt)}) (#${member.guild.memberCount})`
 		);
 	}
 }


### PR DESCRIPTION
This pull request adds the total number of users in the guild in the member join log message when a new member joins the discord. This could be useful for finding milestone members such as 100k, which is coming up soon.