### PR TITLE
Mass Mention Automod Rework

### DIFF
--- a/src/client/minehutClient.ts
+++ b/src/client/minehutClient.ts
@@ -35,6 +35,7 @@ export class MinehutClient extends AkairoClient {
 	starboardCooldownManager: CooldownManager;
 
 	githubCacheManager: CacheManager<number, any>;
+	mentionCacheManager: CacheManager<string, Message>;
 
 	minehutApi: Minehut;
 
@@ -113,6 +114,7 @@ export class MinehutClient extends AkairoClient {
 		this.starboardCooldownManager = new CooldownManager(10000);
 
 		this.githubCacheManager = new CacheManager(600000);
+		this.mentionCacheManager = new CacheManager(15000);
 
 		this.minehutApi = new Minehut();
 
@@ -246,6 +248,7 @@ declare module 'discord-akairo' {
 			number,
 			Promise<OctokitResponse<IssuesGetResponseData>>
 		>;
+		mentionCacheManager: CacheManager<string, Message>;
 		minehutApi: Minehut;
 
 		start(token: string): Promise<void>;

--- a/src/structure/cacheManager.ts
+++ b/src/structure/cacheManager.ts
@@ -24,6 +24,10 @@ export class CacheManager<K, V> {
 		return null;
 	}
 
+	filterValues(predicate: (v: V, k?: K) => boolean) {
+		return this.store.filter(predicate);
+	}
+
 	getLastUpdate(key: K) {
 		if (this.time.has(key) && this.store.has(key)) return this.time.get(key);
 		return null;


### PR DESCRIPTION
Mass mentions are now not based solely on a single message, they are now based on an accumulation of pings across several messages. This is to combat the recent raid attacks where the attacker circumvents the mass mention count to get away with pinging a large amount of users.

This PR also adds `CacheManager#filterValues` to filter the mention cache for messages that some user has made with mentions to determine the accumulated mention count.