### PR TITLE
Fix Temp Mutes not Expiring

### DIFF
--- a/src/structure/scheduler/banScheduler.ts
+++ b/src/structure/scheduler/banScheduler.ts
@@ -21,17 +21,17 @@ export class BanScheduler {
 		// This query will find bans/forcebans that are expiring within 3 days
 		const bansExpiringSoon = await CaseModel.find({
 			$or: [{ type: CaseType.Ban }, { type: CaseType.ForceBan }],
-			expiresAt: { $lte: new Date(Date.now() + EXPIRING_SOON_MS) },
+			expiresAt: {
+				$lte: new Date(Date.now() + EXPIRING_SOON_MS),
+				$gte: new Date(Date.now() - EXPIRING_SOON_MS),
+			},
 			active: true,
 		});
 		bansExpiringSoon.forEach(c => {
 			const expiredDuration = c.expiresAt.getTime() - Date.now();
 			if (expiredDuration > 0) {
-				const timeout = setTimeout(
-					() => this.unban(c),
-					expiredDuration
-				);
-				this.timeouts.set(timeout, c);	
+				const timeout = setTimeout(() => this.unban(c), expiredDuration);
+				this.timeouts.set(timeout, c);
 			} else {
 				this.unban(c);
 			}

--- a/src/structure/scheduler/banScheduler.ts
+++ b/src/structure/scheduler/banScheduler.ts
@@ -23,7 +23,6 @@ export class BanScheduler {
 			$or: [{ type: CaseType.Ban }, { type: CaseType.ForceBan }],
 			expiresAt: {
 				$lte: new Date(Date.now() + EXPIRING_SOON_MS),
-				$gte: new Date(Date.now() - EXPIRING_SOON_MS),
 			},
 			active: true,
 		});

--- a/src/structure/scheduler/muteScheduler.ts
+++ b/src/structure/scheduler/muteScheduler.ts
@@ -23,7 +23,6 @@ export class MuteScheduler {
 			$or: [{ type: CaseType.Mute }, { type: CaseType.VoiceMute }],
 			expiresAt: {
 				$lte: new Date(Date.now() + EXPIRING_SOON_MS),
-				$gte: new Date(Date.now() - EXPIRING_SOON_MS),
 			},
 			active: true,
 		});


### PR DESCRIPTION
This PR fixes temp mutes not expiring in specific cases where the member was not cached by fetching them. 

The changes made to `BanScheduler` are just changes made from Prettier. I originally updated the database queries for both schedulers, but upon further investigation, these queries did not need updating. 