### PR TITLE
Bulk delete mass mention messages across channels

### DIFF
--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -67,10 +67,7 @@ export function humanReadableCaseType(
 
 // This function will format a Date object to a string like DD/MM/YYYY HH:MM:SS and optionally (x time ago), by default if the Date is -1 it will return "N/A"
 // I wrote it in util so I don't need to copy this in every command that needs nice dates
-export function prettyDate(
-	date: Date,
-	relative: boolean = true,
-) {
+export function prettyDate(date: Date, relative: boolean = true) {
 	if (date.getTime() === -1) return 'N/A';
 	const now = Math.round(date.getTime() / 1000);
 	if (relative) return `<t:${now}> (<t:${now}:R>)`;
@@ -390,4 +387,15 @@ export async function getIssue(
 	} catch {
 		return null;
 	}
+}
+
+export function groupMessagesByChannel(msgs: Message[]) {
+	const msgsCollectedByChannel: Message[][] = [];
+	while (msgs.length != 0) {
+		msgsCollectedByChannel.push(
+			msgs.filter(msg => msg.channel.id == msgs[0].channel.id)
+		);
+		msgs = msgs.filter(msg => msg.channel.id != msgs[0].channel.id);
+	}
+	return msgsCollectedByChannel;
 }


### PR DESCRIPTION
This pull request addresses a rather inefficient way of deleting messages in the mass mention automod. The old way of deleting the messages was iterating through the messages array and deleting them that way. The problem with this was, after a certain amount of messages, the bot would be rate limited and might not even delete all the messages. This PR tackles that problem by grouping messages by channel and using discord.js's [`TextChannel#bulkDelete`](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=bulkDelete) method to delete arrays of messages across multiple channels.