### PR TITLE
Fix !server showing invalid date.

### DIFF
--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -68,10 +68,14 @@ export function humanReadableCaseType(
 // This function will format a Date object to a string like DD/MM/YYYY HH:MM:SS and optionally (x time ago), by default if the Date is -1 it will return "N/A"
 // I wrote it in util so I don't need to copy this in every command that needs nice dates
 export function prettyDate(date: Date, relative: boolean = true) {
-	if (date.getTime() === -1) return 'N/A';
+	if (date.getTime() === -1 || !isValidDate(date)) return 'N/A';
 	const now = Math.round(date.getTime() / 1000);
 	if (relative) return `<t:${now}> (<t:${now}:R>)`;
 	return `<t:${now}>`;
+}
+
+function isValidDate(date: Date) {
+	return date instanceof Date && !isNaN(date.valueOf())
 }
 
 // Thanks to https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -75,7 +75,7 @@ export function prettyDate(date: Date, relative: boolean = true) {
 }
 
 function isValidDate(date: Date) {
-	return date instanceof Date && !isNaN(date.valueOf())
+	return date instanceof Date && !isNaN(date.valueOf());
 }
 
 // Thanks to https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript


### PR DESCRIPTION
Sometimes the API response when requesting a server doesn't provide a lastOnline property in the returned JSON, this results in the Last Started section of !server showing as `<t:NaN> (<t:NaN:R>)`, this change fixes that and returns N/A as it should. 