### PR TITLE
added Minehut Gaming Studio to invite whitelist

### DIFF
--- a/src/guild/config/common.ts
+++ b/src/guild/config/common.ts
@@ -29,6 +29,7 @@ export const HASTEBIN_EXTENSIONS_WHITELIST = [
 export const INVITE_WHITELIST = [
 	'239599059415859200', // Minehut
 	'546414872196415501', // Minehut Meta
+	'920080419272159264', // Minehut Gaming Studio
 	'405124395401609218', // Super League Gaming Official
 	'302094807046684672', // MINECRAFT
 


### PR DESCRIPTION
Added the new Minehut Gaming Studio discord server that is used for Twitch Rivals testings and other things to the invite whitelist so it can be sent if someone asks about it.