### PR TITLE
Rename `Updated at` field in tag information

### DIFF
--- a/src/command/tag/info.ts
+++ b/src/command/tag/info.ts
@@ -56,7 +56,7 @@ export default class TagInfoCommand extends MinehutCommand {
 			author ? `${author.tag} (${author.id})` : `<@${tag.author}>`
 		);
 		embed.addField('Created at', prettyDate(tag.createdAt), true);
-		embed.addField('Updated at', prettyDate(tag.updatedAt), true);
+		embed.addField('Last interaction at', prettyDate(tag.updatedAt), true);
 		msg.channel.send({ embeds: [embed] });
 	}
 }


### PR DESCRIPTION
The field `Updated at` implies that it should display the last time the tag content was updated, but instead this displays the last time the tag was interacted with at all (whether it be a use in community-help, tag content update, rename, etc.).

This occurs because Mongoose automatically increments the `updatedAt` field anytime the document is modified, which includes tag usage, since showing a tag increments the `uses` property.
I rename the field to make it not misleading.